### PR TITLE
EY-396: Optional datofelter skal ikke validere tomme felter.

### DIFF
--- a/apps/selvbetjening-ui/client/src/components/felles/Datovelger.tsx
+++ b/apps/selvbetjening-ui/client/src/components/felles/Datovelger.tsx
@@ -59,7 +59,7 @@ const Datovelger = ({ name, label, description, minDate, maxDate, valgfri, class
                     defaultValue={undefined}
                     rules={{
                         required: !valgfri,
-                        validate: (date) => isValid(date)
+                        validate: (date) => !date || isValid(date)
                     }}
                     render={({ field: { onChange, value } }) => (
                         <Datepicker


### PR DESCRIPTION
Den oppdaterte datovelger-komponenten respekterer ikke "required = false" etter at vi la til validering, ettersom valideringen krever at feltet er satt (kjøres selv om "date" ikke har verdi).

Ser ut som dette er alt som skal til, men test gjerne dere også 🙃 