### PR TITLE
EY-425 Oppdatere rapport til å kun hente siste status pr søknad

### DIFF
--- a/apps/innsendt-soeknad/src/main/kotlin/soeknad/SoeknadDao.kt
+++ b/apps/innsendt-soeknad/src/main/kotlin/soeknad/SoeknadDao.kt
@@ -309,11 +309,17 @@ private object Queries {
     """.trimIndent()
 
     val SELECT_RAPPORT = """
-        SELECT status.id, count(1)
-        FROM hendelse h
-        INNER JOIN status ON h.status_id = status.id
-        GROUP BY status.id, status.rang
-        ORDER BY status.rang
+        SELECT st.id, count(1)
+        FROM (
+            SELECT DISTINCT(h.soeknad_id), MAX(s.rang) rang
+            FROM hendelse h
+            INNER JOIN status s on h.status_id = s.id
+            GROUP BY h.soeknad_id
+        ) h2
+            INNER JOIN
+            status st ON st.rang = h2.rang
+        GROUP BY st.id
+        ORDER BY st.rang;
     """.trimMargin()
 
     val SLETT_ARKIVERTE_SOEKNADER = """


### PR DESCRIPTION
Vil med denne endringen _kun_ vise siste status på hver enkelt søknad. 

I skrivende stund er det totalt 673 søknader i databasen, hvorav 15 kun er kladd. 

Dagens rapport viser _alle_ hendelser sine statuser:
| LAGRETKLADD | FERDIGSTILT | SENDT | ARKIVERT | UTGAATT | SLETTET
| --- | --- | --- | --- |  --- | --- | 
|  2710 | 417 | 419 | 417 | 127 | 114 |

Ny rapport vil vise _kun_ hver enkelt søknad sin siste status:
| LAGRETKLADD | FERDIGSTILT | SENDT | ARKIVERT | UTGAATT | SLETTET
| --- | --- | --- | --- |  --- | --- | 
| 15 | 0 | 0 | 417 | 127 | 114 |

Ny rapport vil med andre ord være en mer nøyaktig representasjon av antall søknader (sum av kolonner er total antall søknader). 