### PR TITLE
Sette expectSuccess til true for å sikre pdfgen

### DIFF
--- a/apps/journalfoer-soeknad/src/main/kotlin/AppBuilder.kt
+++ b/apps/journalfoer-soeknad/src/main/kotlin/AppBuilder.kt
@@ -36,6 +36,7 @@ class AppBuilder(private val props: Map<String, String>) {
     }
 
     private fun pdfhttpclient() = HttpClient(OkHttp) {
+        expectSuccess = true
         install(ContentNegotiation) { jackson() }
 
     }.also {


### PR DESCRIPTION
P.t. vil appen potensielt journalføre bytearray som ikke er en pdf. 
Eksempelvis hvis pdfgen feiler vil ikke feilen fanges opp, og siden så og si _alt_ er en bytearray, regner appen responsen som OK. Kan dermed ende opp med å journalføre en feilmelding som "pdf"... 