### PR TITLE
Nytt prinsipp for dependabot-samling: Samle mest mogleg av det som ve…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,35 +26,33 @@ updates:
       ds:
         patterns:
           - "@navikt/ds-*"
-      eslint:
+      eslint-og-test:
         patterns:
           - "@typescript-eslint/*"
           - "eslint"
           - "eslint-plugin*"
           - "prettier"
-      react:
-        patterns:
-          - "react*"
-          - "@types/react*"
-      lodash:
-        patterns:
-          - "lodash"
-          - "@types/lodash"
-      axios:
-        patterns:
-          - "axios"
-          - "axios-retry"
-      test:
-        patterns:
           - "axe-core"
           - "cypress"
           - "cypress-axe"
           - "@testing-library/*"
           - "@types/jest"
-      uuid:
+      react:
         patterns:
+          - "react*"
+          - "@types/react*"
+      prod:
+        patterns:
+          - "lodash"
+          - "@types/lodash"
+          - "axios"
+          - "axios-retry"
           - "uuid"
           - "@types/uuid"
+          - "@types/node"
+          - "typescript"
+          - "i18next"
+          - "ibantools"
       styledcomponents:
         patterns:
           - "styled-components"
@@ -75,35 +73,33 @@ updates:
       ds:
         patterns:
           - "@navikt/ds-*"
-      eslint:
+      eslint-og-test:
         patterns:
           - "@typescript-eslint/*"
           - "eslint"
           - "eslint-plugin*"
           - "prettier"
-      react:
-        patterns:
-          - "react*"
-          - "@types/react*"
-      lodash:
-        patterns:
-          - "lodash"
-          - "@types/lodash"
-      axios:
-        patterns:
-          - "axios"
-          - "axios-retry"
-      test:
-        patterns:
           - "axe-core"
           - "cypress"
           - "cypress-axe"
           - "@testing-library/*"
           - "@types/jest"
-      uuid:
+      react:
         patterns:
+          - "react*"
+          - "@types/react*"
+      prod:
+        patterns:
+          - "lodash"
+          - "@types/lodash"
+          - "axios"
+          - "axios-retry"
           - "uuid"
           - "@types/uuid"
+          - "typescript"
+          - "ibantools"
+          - "web-vitals"
+          - "i18next"
       styledcomponents:
         patterns:
           - "styled-components"
@@ -123,35 +119,32 @@ updates:
       ds:
         patterns:
           - "@navikt/ds-*"
-      eslint:
+      eslint-og-test:
         patterns:
           - "@typescript-eslint/*"
           - "eslint"
           - "eslint-plugin*"
           - "prettier"
-      react:
-        patterns:
-          - "react*"
-          - "@types/react*"
-      lodash:
-        patterns:
-          - "lodash"
-          - "@types/lodash"
-      axios:
-        patterns:
-          - "axios"
-          - "axios-retry"
-      test:
-        patterns:
           - "axe-core"
           - "cypress"
           - "cypress-axe"
           - "@testing-library/*"
           - "@types/jest"
-      uuid:
+      react:
         patterns:
+          - "react*"
+          - "@types/react*"
+      prod:
+        patterns:
+          - "lodash"
+          - "@types/lodash"
+          - "axios"
+          - "axios-retry"
           - "uuid"
           - "@types/uuid"
+          - "typescript"
+          - "i18next"
+          - "ibantools"
       styledcomponents:
         patterns:
           - "styled-components"
@@ -167,6 +160,10 @@ updates:
       interval: "monthly"
       day: "sunday"
     open-pull-requests-limit: 10
+    groups:
+      prod:
+        patterns:
+          - "*"
 
 
   # ==============


### PR DESCRIPTION
…ldig ofte er trygt, kun hald det som kjens risikabelt ut for seg sjølv.

Erfaringa no er at det er nokre få avhengnadar/pakkar av avhengnadar som treng ekstra sjekk og ofte kodeendringar, men dei fleste gjer ikkje det. Prøver derfor prinsippet om å samle det som er trygt i færrast mogleg PR-ar.

Oppdaga også at vi hadde gløymt å konfigurere opp samling av PR-ar for node-server. Det hadde ikkje dependabot gløymt, for å seie det sånn.