### PR TITLE
Trur greia er at vi bruker deprecated-greier frå typescript som no er sletta derifrå

### DIFF
--- a/apps/barnepensjon-ui/package.json
+++ b/apps/barnepensjon-ui/package.json
@@ -25,7 +25,7 @@
     "react-hook-form": "^7.47.0",
     "react-router-dom": "^6.16.0",
     "styled-components": "^6.1.0",
-    "typescript": "^5.2.2",
+    "typescript": "^5.1.6",
     "uuid": "^9.0.1",
     "web-vitals": "^3.5.0",
     "worker-loader": "^3.0.8"

--- a/apps/barnepensjon-ui/yarn.lock
+++ b/apps/barnepensjon-ui/yarn.lock
@@ -10000,7 +10000,7 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^5.2.2:
+typescript@^5.1.6:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
   integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==


### PR DESCRIPTION
Må i så fall gjera tilsvarande også for oms og gp