### PR TITLE
Vis egne felter for inntekt i norge hvis dødsfall var året før

### DIFF
--- a/apps/omstillingsstoenad-ui/cypress/e2e/enkel_soeknadsflyt.cy.js
+++ b/apps/omstillingsstoenad-ui/cypress/e2e/enkel_soeknadsflyt.cy.js
@@ -179,11 +179,19 @@ describe('Skal gå igjennom hele søknaden uten feil', () => {
         // Næringsinntekt
         selectValueForId('naeringsinntekt.norgeEllerUtland', 'inntekt.norge')
 
+        selectValueForId(
+            'naeringsinntekt.norge.sesongbasertNaeringsinntekt.svar',
+            inntektenDin.naeringsinntekt.sesonbasertNaeringsinntekt.svar
+        )
+        getById('naeringsinntekt.norge.sesongbasertNaeringsinntekt.beskrivelse').type(
+            inntektenDin.naeringsinntekt.sesonbasertNaeringsinntekt.beskrivelse
+        )
+
         getById('naeringsinntekt.norge.arbeidsinntektAaretFoer').type(
             inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer
         )
-        getById('naeringsinntekt.norge.arbeidsinntektIAar.tilDoedsfall').type(
-            inntektenDin.naeringsinntekt.arbeidsinntektIAar.tilDoedsfall
+        getById('naeringsinntekt.norge.arbeidsinntektIAar.aarsinntekt').type(
+            inntektenDin.naeringsinntekt.arbeidsinntektIAar.aarsinntekt
         )
         getById('naeringsinntekt.norge.arbeidsinntektIAar.etterDoedsfall').type(
             inntektenDin.naeringsinntekt.arbeidsinntektIAar.etterDoedsfall

--- a/apps/omstillingsstoenad-ui/cypress/e2e/enkel_soeknadsflyt.cy.js
+++ b/apps/omstillingsstoenad-ui/cypress/e2e/enkel_soeknadsflyt.cy.js
@@ -167,9 +167,11 @@ describe('Skal gå igjennom hele søknaden uten feil', () => {
         getById('loennsinntekt.norge.arbeidsinntektIAar.tilDoedsfall').type(
             inntektenDin.loennsinntekt.arbeidsinntektIAar.tilDoedsfall
         )
+        /*
         getById('loennsinntekt.norge.arbeidsinntektIAar.etterDoedsfall').type(
             inntektenDin.loennsinntekt.arbeidsinntektIAar.etterDoedsfall
         )
+        */
 
         selectValueForId(
             'loennsinntekt.forventerEndringAvInntekt.svar',
@@ -193,9 +195,11 @@ describe('Skal gå igjennom hele søknaden uten feil', () => {
         getById('naeringsinntekt.norge.arbeidsinntektIAar.aarsinntekt').type(
             inntektenDin.naeringsinntekt.arbeidsinntektIAar.aarsinntekt
         )
+        /*
         getById('naeringsinntekt.norge.arbeidsinntektIAar.etterDoedsfall').type(
             inntektenDin.naeringsinntekt.arbeidsinntektIAar.etterDoedsfall
         )
+        */
 
         selectValueForId(
             'naeringsinntekt.forventerEndringAvInntekt.svar',

--- a/apps/omstillingsstoenad-ui/cypress/e2e/enkel_soeknadsflyt.cy.js
+++ b/apps/omstillingsstoenad-ui/cypress/e2e/enkel_soeknadsflyt.cy.js
@@ -47,7 +47,7 @@ describe('Skal gå igjennom hele søknaden uten feil', () => {
         const omDenAvdoede = mockSoeknad.omDenAvdoede
         getById('fornavn').type(omDenAvdoede.fornavn)
         getById('etternavn').type(omDenAvdoede.etternavn)
-        getById('datoForDoedsfallet').type(omDenAvdoede.datoForDoedsfallet)
+        getById('datoForDoedsfallet').type(new Date().toISOString().split('T')[0])
         getById('foedselsnummer').type(omDenAvdoede.foedselsnummer)
         getById('statsborgerskap').find('select').select(omDenAvdoede.statsborgerskap)
         selectValueForId('boddEllerJobbetUtland.svar', omDenAvdoede.boddEllerJobbetUtland.svar)
@@ -179,7 +179,9 @@ describe('Skal gå igjennom hele søknaden uten feil', () => {
         // Næringsinntekt
         selectValueForId('naeringsinntekt.norgeEllerUtland', 'inntekt.norge')
 
-        getById('naeringsinntekt.norge.arbeidsinntektAaretFoer').type(inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer)
+        getById('naeringsinntekt.norge.arbeidsinntektAaretFoer').type(
+            inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer
+        )
         getById('naeringsinntekt.norge.arbeidsinntektIAar.tilDoedsfall').type(
             inntektenDin.naeringsinntekt.arbeidsinntektIAar.tilDoedsfall
         )

--- a/apps/omstillingsstoenad-ui/src/api/dto/FellesOpplysninger.ts
+++ b/apps/omstillingsstoenad-ui/src/api/dto/FellesOpplysninger.ts
@@ -162,6 +162,10 @@ interface InntektsType {
         etterDoedsfall?: Opplysning<FritekstSvar>
         aarsinntekt?: Opplysning<FritekstSvar>
     }
+    sesongbasertNaeringsinntekt?: {
+        svar: Opplysning<EnumSvar<JaNeiVetIkke>>
+        beskrivelse?: Opplysning<FritekstSvar>
+    }
 }
 
 export interface PensjonEllerUfoere {

--- a/apps/omstillingsstoenad-ui/src/api/dto/FellesOpplysninger.ts
+++ b/apps/omstillingsstoenad-ui/src/api/dto/FellesOpplysninger.ts
@@ -156,9 +156,11 @@ export interface LoennsOgNaeringsinntekt {
 
 interface InntektsType {
     arbeidsinntektAaretFoer: Opplysning<FritekstSvar>
+    inntektEtterDoedsfall?: Opplysning<FritekstSvar>
     arbeidsinntektIAar: {
-        tilDoedsfall: Opplysning<FritekstSvar>
+        tilDoedsfall?: Opplysning<FritekstSvar>
         etterDoedsfall?: Opplysning<FritekstSvar>
+        aarsinntekt?: Opplysning<FritekstSvar>
     }
 }
 

--- a/apps/omstillingsstoenad-ui/src/api/mapper/gjenlevendeMapper.ts
+++ b/apps/omstillingsstoenad-ui/src/api/mapper/gjenlevendeMapper.ts
@@ -634,15 +634,15 @@ const hentInntektOgPensjon = (t: TFunction, inntektenDin: IInntekt, datoForDoeds
                     ? {
                           arbeidsinntektAaretFoer: {
                               spoersmaal: doedsfallIAar
-                                  ? t('inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer.doedsfallAaretFoer')
-                                  : t('inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer'),
+                                  ? t('inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer')
+                                  : t('inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer'),
                               svar: {
                                   innhold: inntektenDin.loennsinntekt!!.norge!!.arbeidsinntektAaretFoer!!,
                               },
                           },
                           inntektEtterDoedsfall: doedsfallIAar
                               ? {
-                                    spoersmaal: t('inntektenDin.loennsinntekt.norge.inntektEtterDoedsfall'),
+                                    spoersmaal: t('inntektenDin.loennsinntekt.inntektEtterDoedsfall'),
                                     svar: {
                                         innhold: inntektenDin.loennsinntekt!!.norge!!.inntektEtterDoedsfall!!,
                                     },
@@ -651,9 +651,7 @@ const hentInntektOgPensjon = (t: TFunction, inntektenDin: IInntekt, datoForDoeds
                           arbeidsinntektIAar: doedsfallIAar
                               ? {
                                     aarsinntekt: {
-                                        spoersmaal: t(
-                                            'inntektenDin.loennsinntekt.norge.arbeidsinntektIAar.aarsinntekt'
-                                        ),
+                                        spoersmaal: t('inntektenDin.loennsinntekt.arbeidsinntektIAar.aarsinntekt'),
                                         svar: {
                                             innhold:
                                                 inntektenDin.loennsinntekt!!.norge!!.arbeidsinntektIAar!!.aarsinntekt!!,
@@ -690,32 +688,48 @@ const hentInntektOgPensjon = (t: TFunction, inntektenDin: IInntekt, datoForDoeds
                 utland: inntektenDin.loennsinntekt!!.norgeEllerUtland.includes(NorgeOgUtland.utland)
                     ? {
                           arbeidsinntektAaretFoer: {
-                              spoersmaal: t('inntektenDin.loennsinntekt.utland.arbeidsinntektAaretFoer'),
+                              spoersmaal: doedsfallIAar
+                                  ? t('inntektenDin.loennsinntekt.utland.arbeidsinntektAaretFoer')
+                                  : t('inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer'),
                               svar: {
                                   innhold: inntektenDin.loennsinntekt!!.utland!!.arbeidsinntektAaretFoer!!,
                               },
                           },
-                          arbeidsinntektIAar: {
-                              tilDoedsfall: {
-                                  spoersmaal: t('inntektenDin.loennsinntekt.utland.arbeidsinntektIAar.tilDoedsfall'),
-                                  svar: {
-                                      innhold:
-                                          inntektenDin.loennsinntekt!!.utland!!.arbeidsinntektIAar!!.tilDoedsfall!!,
-                                  },
-                              },
-                              etterDoedsfall: inntektenDin.loennsinntekt!!.utland!!.arbeidsinntektIAar!!.etterDoedsfall
-                                  ? {
+                          arbeidsinntektIAar: doedsfallIAar
+                              ? {
+                                    aarsinntekt: {
+                                        spoersmaal: t('inntektenDin.loennsinntekt.arbeidsinntektIAar.aarsinntekt'),
+                                        svar: {
+                                            innhold:
+                                                inntektenDin.loennsinntekt!!.utland!!.arbeidsinntektIAar!!.aarsinntekt!!,
+                                        },
+                                    },
+                                }
+                              : {
+                                    tilDoedsfall: {
                                         spoersmaal: t(
-                                            'inntektenDin.loennsinntekt.utland.arbeidsinntektIAar.etterDoedsfall'
+                                            'inntektenDin.loennsinntekt.utland.arbeidsinntektIAar.tilDoedsfall'
                                         ),
                                         svar: {
                                             innhold:
                                                 inntektenDin.loennsinntekt!!.utland!!.arbeidsinntektIAar!!
-                                                    .etterDoedsfall!!,
+                                                    .tilDoedsfall!!,
                                         },
-                                    }
-                                  : undefined,
-                          },
+                                    },
+                                    etterDoedsfall: inntektenDin.loennsinntekt!!.utland!!.arbeidsinntektIAar!!
+                                        .etterDoedsfall
+                                        ? {
+                                              spoersmaal: t(
+                                                  'inntektenDin.loennsinntekt.utland.arbeidsinntektIAar.etterDoedsfall'
+                                              ),
+                                              svar: {
+                                                  innhold:
+                                                      inntektenDin.loennsinntekt!!.utland!!.arbeidsinntektIAar!!
+                                                          .etterDoedsfall!!,
+                                              },
+                                          }
+                                        : undefined,
+                                },
                       }
                     : undefined,
                 endringAvInntekt: mapEndringAvInntekt(t, inntektenDin.loennsinntekt!!.forventerEndringAvInntekt),

--- a/apps/omstillingsstoenad-ui/src/api/mapper/gjenlevendeMapper.ts
+++ b/apps/omstillingsstoenad-ui/src/api/mapper/gjenlevendeMapper.ts
@@ -637,7 +637,9 @@ const hentInntektOgPensjon = (t: TFunction, inntektenDin: IInntekt, datoForDoeds
                                   ? t('inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer')
                                   : t('inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer'),
                               svar: {
-                                  innhold: inntektenDin.loennsinntekt!!.norge!!.arbeidsinntektAaretFoer!!,
+                                  innhold: doedsfallIAar
+                                      ? inntektenDin.loennsinntekt!!.norge!!.arbeidsinntektAaretFoer!!
+                                      : inntektenDin.loennsinntekt!!.norge!!.arbeidsinntektDoedsfallsaaret!!,
                               },
                           },
                           inntektEtterDoedsfall: doedsfallIAar
@@ -692,7 +694,9 @@ const hentInntektOgPensjon = (t: TFunction, inntektenDin: IInntekt, datoForDoeds
                                   ? t('inntektenDin.loennsinntekt.utland.arbeidsinntektAaretFoer')
                                   : t('inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer'),
                               svar: {
-                                  innhold: inntektenDin.loennsinntekt!!.utland!!.arbeidsinntektAaretFoer!!,
+                                  innhold: doedsfallIAar
+                                      ? inntektenDin.loennsinntekt!!.utland!!.arbeidsinntektAaretFoer!!
+                                      : inntektenDin.loennsinntekt!!.utland!!.arbeidsinntektDoedsfallsaaret!!,
                               },
                           },
                           inntektEtterDoedsfall: doedsfallIAar
@@ -787,7 +791,9 @@ const hentInntektOgPensjon = (t: TFunction, inntektenDin: IInntekt, datoForDoeds
                                   ? t('inntektenDin.naeringsinntekt.norge.arbeidsinntektAaretFoer')
                                   : t('inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer'),
                               svar: {
-                                  innhold: inntektenDin.naeringsinntekt!!.norge!!.arbeidsinntektAaretFoer!!,
+                                  innhold: doedsfallIAar
+                                      ? inntektenDin.naeringsinntekt!!.norge!!.arbeidsinntektAaretFoer!!
+                                      : inntektenDin.naeringsinntekt!!.norge!!.arbeidsinntektDoedsfallsaaret!!,
                               },
                           },
                           arbeidsinntektIAar: {
@@ -843,7 +849,9 @@ const hentInntektOgPensjon = (t: TFunction, inntektenDin: IInntekt, datoForDoeds
                                   ? t('inntektenDin.naeringsinntekt.utland.arbeidsinntektAaretFoer')
                                   : t('inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer'),
                               svar: {
-                                  innhold: inntektenDin.naeringsinntekt!!.utland!!.arbeidsinntektAaretFoer!!,
+                                  innhold: doedsfallIAar
+                                      ? inntektenDin.naeringsinntekt!!.norge!!.arbeidsinntektAaretFoer!!
+                                      : inntektenDin.naeringsinntekt!!.norge!!.arbeidsinntektDoedsfallsaaret!!,
                               },
                           },
                           arbeidsinntektIAar: {

--- a/apps/omstillingsstoenad-ui/src/api/mapper/gjenlevendeMapper.ts
+++ b/apps/omstillingsstoenad-ui/src/api/mapper/gjenlevendeMapper.ts
@@ -695,6 +695,14 @@ const hentInntektOgPensjon = (t: TFunction, inntektenDin: IInntekt, datoForDoeds
                                   innhold: inntektenDin.loennsinntekt!!.utland!!.arbeidsinntektAaretFoer!!,
                               },
                           },
+                          inntektEtterDoedsfall: doedsfallIAar
+                              ? {
+                                    spoersmaal: t('inntektenDin.loennsinntekt.inntektEtterDoedsfall'),
+                                    svar: {
+                                        innhold: inntektenDin.loennsinntekt!!.norge!!.inntektEtterDoedsfall!!,
+                                    },
+                                }
+                              : undefined,
                           arbeidsinntektIAar: doedsfallIAar
                               ? {
                                     aarsinntekt: {

--- a/apps/omstillingsstoenad-ui/src/api/mapper/gjenlevendeMapper.ts
+++ b/apps/omstillingsstoenad-ui/src/api/mapper/gjenlevendeMapper.ts
@@ -701,7 +701,8 @@ const hentInntektOgPensjon = (t: TFunction, inntektenDin: IInntekt, datoForDoeds
                                         spoersmaal: t('inntektenDin.loennsinntekt.arbeidsinntektIAar.aarsinntekt'),
                                         svar: {
                                             innhold:
-                                                inntektenDin.loennsinntekt!!.utland!!.arbeidsinntektIAar!!.aarsinntekt!!,
+                                                inntektenDin.loennsinntekt!!.utland!!.arbeidsinntektIAar!!
+                                                    .aarsinntekt!!,
                                         },
                                     },
                                 }
@@ -751,76 +752,98 @@ const hentInntektOgPensjon = (t: TFunction, inntektenDin: IInntekt, datoForDoeds
                 },
                 norge: inntektenDin.naeringsinntekt!!.norgeEllerUtland.includes(NorgeOgUtland.norge)
                     ? {
+                          sesongbasertNaeringsinntekt: {
+                              svar: {
+                                  spoersmaal: t('inntektenDin.naeringsinntekt.sesongbasertNaeringsinntekt.svar'),
+                                  svar: valgTilSvar(
+                                      t,
+                                      inntektenDin.naeringsinntekt!!.norge!!.sesongbasertNaeringsinntekt!!.svar!!
+                                  ),
+                              },
+                              beskrivelse:
+                                  inntektenDin.naeringsinntekt!!.norge!!.sesongbasertNaeringsinntekt!!.svar === IValg.JA
+                                      ? {
+                                            spoersmaal: t(
+                                                'inntektenDin.naeringsinntekt.sesongbasertNaeringsinntekt.beskrivelse'
+                                            ),
+                                            svar: {
+                                                innhold:
+                                                    inntektenDin.naeringsinntekt!!.norge!!.sesongbasertNaeringsinntekt!!
+                                                        .beskrivelse!!,
+                                            },
+                                        }
+                                      : undefined,
+                          },
                           arbeidsinntektAaretFoer: {
                               spoersmaal: doedsfallIAar
                                   ? t('inntektenDin.naeringsinntekt.norge.arbeidsinntektAaretFoer')
-                                  : t('inntektenDin.naeringsinntekt.norge.arbeidsinntektAaretFoer.doedsfallAaretFoer'),
+                                  : t('inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer'),
                               svar: {
                                   innhold: inntektenDin.naeringsinntekt!!.norge!!.arbeidsinntektAaretFoer!!,
                               },
                           },
-                          inntektEtterDoedsfall: doedsfallIAar
-                              ? {
-                                    spoersmaal: t('inntektenDin.naeringsinntekt.norge.inntektEtterDoedsfall'),
-                                    svar: {
-                                        innhold: inntektenDin.naeringsinntekt!!.norge!!.inntektEtterDoedsfall!!,
-                                    },
-                                }
-                              : undefined,
-                          arbeidsinntektIAar: doedsfallIAar
-                              ? {
-                                    tilDoedsfall: {
+                          arbeidsinntektIAar: {
+                              aarsinntekt: {
+                                  spoersmaal: t('inntektenDin.naeringsinntekt.arbeidsinntektIAar.aarsinntekt'),
+                                  svar: {
+                                      innhold:
+                                          inntektenDin.naeringsinntekt!!.norge!!.arbeidsinntektIAar!!.aarsinntekt!!,
+                                  },
+                              },
+                              etterDoedsfall: inntektenDin.naeringsinntekt!!.norge!!.arbeidsinntektIAar!!.etterDoedsfall
+                                  ? {
                                         spoersmaal: t(
-                                            'inntektenDin.naeringsinntekt.norge.arbeidsinntektIAar.tilDoedsfall'
+                                            'inntektenDin.naeringsinntekt.norge.arbeidsinntektIAar.etterDoedsfall'
                                         ),
                                         svar: {
                                             innhold:
                                                 inntektenDin.naeringsinntekt!!.norge!!.arbeidsinntektIAar!!
-                                                    .tilDoedsfall!!,
+                                                    .etterDoedsfall!!,
                                         },
-                                    },
-                                    etterDoedsfall: inntektenDin.naeringsinntekt!!.norge!!.arbeidsinntektIAar!!
-                                        .etterDoedsfall
-                                        ? {
-                                              spoersmaal: t(
-                                                  'inntektenDin.naeringsinntekt.norge.arbeidsinntektIAar.etterDoedsfall'
-                                              ),
-                                              svar: {
-                                                  innhold:
-                                                      inntektenDin.naeringsinntekt!!.norge!!.arbeidsinntektIAar!!
-                                                          .etterDoedsfall!!,
-                                              },
-                                          }
-                                        : undefined,
-                                }
-                              : {
-                                    aarsinntekt: {
-                                        spoersmaal: t(
-                                            'inntektenDin.naeringsinntekt.norge.arbeidsinntektIAar.aarsinntekt'
-                                        ),
-                                        svar: {
-                                            innhold:
-                                                inntektenDin.naeringsinntekt!!.norge!!.arbeidsinntektIAar!!
-                                                    .aarsinntekt!!,
-                                        },
-                                    },
-                                },
+                                    }
+                                  : undefined,
+                          },
                       }
                     : undefined,
                 utland: inntektenDin.naeringsinntekt!!.norgeEllerUtland.includes(NorgeOgUtland.utland)
                     ? {
+                          sesongbasertNaeringsinntekt: {
+                              svar: {
+                                  spoersmaal: t('inntektenDin.naeringsinntekt.sesongbasertNaeringsinntekt.svar'),
+                                  svar: valgTilSvar(
+                                      t,
+                                      inntektenDin.naeringsinntekt!!.utland!!.sesongbasertNaeringsinntekt!!.svar!!
+                                  ),
+                              },
+                              beskrivelse:
+                                  inntektenDin.naeringsinntekt!!.utland!!.sesongbasertNaeringsinntekt!!.svar ===
+                                  IValg.JA
+                                      ? {
+                                            spoersmaal: t(
+                                                'inntektenDin.naeringsinntekt.sesongbasertNaeringsinntekt.beskrivelse'
+                                            ),
+                                            svar: {
+                                                innhold:
+                                                    inntektenDin.naeringsinntekt!!.utland!!
+                                                        .sesongbasertNaeringsinntekt!!.beskrivelse!!,
+                                            },
+                                        }
+                                      : undefined,
+                          },
                           arbeidsinntektAaretFoer: {
-                              spoersmaal: t('inntektenDin.naeringsinntekt.utland.arbeidsinntektAaretFoer'),
+                              spoersmaal: doedsfallIAar
+                                  ? t('inntektenDin.naeringsinntekt.utland.arbeidsinntektAaretFoer')
+                                  : t('inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer'),
                               svar: {
                                   innhold: inntektenDin.naeringsinntekt!!.utland!!.arbeidsinntektAaretFoer!!,
                               },
                           },
                           arbeidsinntektIAar: {
-                              tilDoedsfall: {
-                                  spoersmaal: t('inntektenDin.naeringsinntekt.utland.arbeidsinntektIAar.tilDoedsfall'),
+                              aarsinntekt: {
+                                  spoersmaal: t('inntektenDin.naeringsinntekt.arbeidsinntektIAar.aarsinntekt'),
                                   svar: {
                                       innhold:
-                                          inntektenDin.naeringsinntekt!!.utland!!.arbeidsinntektIAar!!.tilDoedsfall!!,
+                                          inntektenDin.naeringsinntekt!!.utland!!.arbeidsinntektIAar!!.aarsinntekt!!,
                                   },
                               },
                               etterDoedsfall: inntektenDin.naeringsinntekt!!.utland!!.arbeidsinntektIAar!!

--- a/apps/omstillingsstoenad-ui/src/assets/dummy-soeknad.json
+++ b/apps/omstillingsstoenad-ui/src/assets/dummy-soeknad.json
@@ -130,9 +130,13 @@
       }
     },
     "naeringsinntekt": {
+      "sesonbasertNaeringsinntekt": {
+        "svar": "radiobuttons.ja",
+        "beskrivelse": "Selger julelys i desember"
+      },
       "arbeidsinntektAaretFoer": "10000",
       "arbeidsinntektIAar": {
-        "tilDoedsfall": "20000",
+        "aarsinntekt": "20000",
         "etterDoedsfall": "30000"
       },
       "forventerEndringAvInntekt": {

--- a/apps/omstillingsstoenad-ui/src/components/soknad/6-inntekten-din/fragmenter/Loennsinntekt.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/soknad/6-inntekten-din/fragmenter/Loennsinntekt.tsx
@@ -65,17 +65,6 @@ const Loennsinntekt = () => {
                                         htmlSize={Bredde.S}
                                     />
                                 </SkjemaElement>
-                                {erMellomOktoberogDesember() && (
-                                    <SkjemaElement>
-                                        <RHFValutaInput
-                                            name={'loennsinntekt.norge.arbeidsinntektIAar.etterDoedsfall'}
-                                            label={t(
-                                                'inntektenDin.loennsinntekt.norge.arbeidsinntektIAar.etterDoedsfall'
-                                            )}
-                                            htmlSize={Bredde.S}
-                                        />
-                                    </SkjemaElement>
-                                )}
                             </SkjemaGruppe>
                         </>
                     ) : (
@@ -83,9 +72,7 @@ const Loennsinntekt = () => {
                             <SkjemaGruppe>
                                 <RHFValutaInput
                                     name={'loennsinntekt.norge.arbeidsinntektAaretFoer'}
-                                    label={t(
-                                        'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer'
-                                    )}
+                                    label={t('inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer')}
                                     description={t(
                                         'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse'
                                     )}
@@ -97,9 +84,7 @@ const Loennsinntekt = () => {
                                     <RHFValutaInput
                                         name={'loennsinntekt.norge.inntektEtterDoedsfall'}
                                         label={t('inntektenDin.loennsinntekt.inntektEtterDoedsfall')}
-                                        description={t(
-                                            'inntektenDin.loennsinntekt.inntektEtterDoedsfall.beskrivelse'
-                                        )}
+                                        description={t('inntektenDin.loennsinntekt.inntektEtterDoedsfall.beskrivelse')}
                                         htmlSize={Bredde.S}
                                     />
                                 </SkjemaElement>
@@ -115,6 +100,15 @@ const Loennsinntekt = () => {
                                 </SkjemaElement>
                             </SkjemaGruppe>
                         </>
+                    )}
+                    {erMellomOktoberogDesember() && (
+                        <SkjemaElement>
+                            <RHFValutaInput
+                                name={'loennsinntekt.norge.arbeidsinntektIAar.etterDoedsfall'}
+                                label={t('inntektenDin.loennsinntekt.norge.arbeidsinntektIAar.etterDoedsfall')}
+                                htmlSize={Bredde.S}
+                            />
+                        </SkjemaElement>
                     )}
                 </>
             )}
@@ -150,17 +144,6 @@ const Loennsinntekt = () => {
                                         htmlSize={Bredde.S}
                                     />
                                 </SkjemaElement>
-                                {erMellomOktoberogDesember() && (
-                                    <SkjemaElement>
-                                        <RHFValutaInput
-                                            name={'loennsinntekt.utland.arbeidsinntektIAar.etterDoedsfall'}
-                                            label={t(
-                                                'inntektenDin.loennsinntekt.utland.arbeidsinntektIAar.etterDoedsfall'
-                                            )}
-                                            htmlSize={Bredde.S}
-                                        />
-                                    </SkjemaElement>
-                                )}
                             </SkjemaGruppe>
                         </>
                     ) : (
@@ -168,9 +151,7 @@ const Loennsinntekt = () => {
                             <SkjemaGruppe>
                                 <RHFValutaInput
                                     name={'loennsinntekt.utland.arbeidsinntektAaretFoer'}
-                                    label={t(
-                                        'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer'
-                                    )}
+                                    label={t('inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer')}
                                     description={t(
                                         'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse'
                                     )}
@@ -182,9 +163,7 @@ const Loennsinntekt = () => {
                                     <RHFValutaInput
                                         name={'loennsinntekt.utland.inntektEtterDoedsfall'}
                                         label={t('inntektenDin.loennsinntekt.inntektEtterDoedsfall')}
-                                        description={t(
-                                            'inntektenDin.loennsinntekt.inntektEtterDoedsfall.beskrivelse'
-                                        )}
+                                        description={t('inntektenDin.loennsinntekt.inntektEtterDoedsfall.beskrivelse')}
                                         htmlSize={Bredde.S}
                                     />
                                 </SkjemaElement>
@@ -200,6 +179,15 @@ const Loennsinntekt = () => {
                                 </SkjemaElement>
                             </SkjemaGruppe>
                         </>
+                    )}
+                    {erMellomOktoberogDesember() && (
+                        <SkjemaElement>
+                            <RHFValutaInput
+                                name={'loennsinntekt.utland.arbeidsinntektIAar.etterDoedsfall'}
+                                label={t('inntektenDin.loennsinntekt.utland.arbeidsinntektIAar.etterDoedsfall')}
+                                htmlSize={Bredde.S}
+                            />
+                        </SkjemaElement>
                     )}
                 </>
             )}

--- a/apps/omstillingsstoenad-ui/src/components/soknad/6-inntekten-din/fragmenter/Loennsinntekt.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/soknad/6-inntekten-din/fragmenter/Loennsinntekt.tsx
@@ -153,7 +153,7 @@ const Loennsinntekt = () => {
                                     name={'loennsinntekt.utland.arbeidsinntektAaretFoer'}
                                     label={t('inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer')}
                                     description={t(
-                                        'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse'
+                                        'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse.utland'
                                     )}
                                     htmlSize={Bredde.S}
                                 />

--- a/apps/omstillingsstoenad-ui/src/components/soknad/6-inntekten-din/fragmenter/Loennsinntekt.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/soknad/6-inntekten-din/fragmenter/Loennsinntekt.tsx
@@ -93,7 +93,7 @@ const Loennsinntekt = () => {
                                         name={'loennsinntekt.norge.arbeidsinntektIAar.aarsinntekt'}
                                         label={t('inntektenDin.loennsinntekt.arbeidsinntektIAar.aarsinntekt')}
                                         description={t(
-                                            'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse'
+                                            'inntektenDin.loennsinntekt.arbeidsinntektIAar.aarsinntekt.beskrivelse'
                                         )}
                                         htmlSize={Bredde.S}
                                     />
@@ -172,7 +172,7 @@ const Loennsinntekt = () => {
                                         name={'loennsinntekt.utland.arbeidsinntektIAar.aarsinntekt'}
                                         label={t('inntektenDin.loennsinntekt.arbeidsinntektIAar.aarsinntekt')}
                                         description={t(
-                                            'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse'
+                                            'inntektenDin.loennsinntekt.arbeidsinntektIAar.aarsinntekt.beskrivelse'
                                         )}
                                         htmlSize={Bredde.S}
                                     />

--- a/apps/omstillingsstoenad-ui/src/components/soknad/6-inntekten-din/fragmenter/Loennsinntekt.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/soknad/6-inntekten-din/fragmenter/Loennsinntekt.tsx
@@ -84,10 +84,10 @@ const Loennsinntekt = () => {
                                 <RHFValutaInput
                                     name={'loennsinntekt.norge.arbeidsinntektAaretFoer'}
                                     label={t(
-                                        'inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer.doedsfallAaretFoer'
+                                        'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer'
                                     )}
                                     description={t(
-                                        'inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse'
+                                        'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse'
                                     )}
                                     htmlSize={Bredde.S}
                                 />
@@ -96,9 +96,9 @@ const Loennsinntekt = () => {
                                 <SkjemaElement>
                                     <RHFValutaInput
                                         name={'loennsinntekt.norge.inntektEtterDoedsfall'}
-                                        label={t('inntektenDin.loennsinntekt.norge.inntektEtterDoedsfall')}
+                                        label={t('inntektenDin.loennsinntekt.inntektEtterDoedsfall')}
                                         description={t(
-                                            'inntektenDin.loennsinntekt.norge.inntektEtterDoedsfall.beskrivelse'
+                                            'inntektenDin.loennsinntekt.inntektEtterDoedsfall.beskrivelse'
                                         )}
                                         htmlSize={Bredde.S}
                                     />
@@ -106,9 +106,9 @@ const Loennsinntekt = () => {
                                 <SkjemaElement>
                                     <RHFValutaInput
                                         name={'loennsinntekt.norge.arbeidsinntektIAar.aarsinntekt'}
-                                        label={t('inntektenDin.loennsinntekt.norge.arbeidsinntektIAar.aarsinntekt')}
+                                        label={t('inntektenDin.loennsinntekt.arbeidsinntektIAar.aarsinntekt')}
                                         description={t(
-                                            'inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse'
+                                            'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse'
                                         )}
                                         htmlSize={Bredde.S}
                                     />
@@ -126,36 +126,81 @@ const Loennsinntekt = () => {
                     <SkjemaElement>
                         <Heading size={'small'}>{t('inntektenDin.loennsinntekt.norgeEllerUtland.utland')}</Heading>
                     </SkjemaElement>
-                    <SkjemaGruppe>
-                        <RHFValutaInput
-                            name={'loennsinntekt.utland.arbeidsinntektAaretFoer'}
-                            label={t('inntektenDin.loennsinntekt.utland.arbeidsinntektAaretFoer')}
-                            description={t('inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.beskrivelse.utland')}
-                            htmlSize={Bredde.S}
-                        />
-                    </SkjemaGruppe>
-
-                    <SkjemaGruppe>
-                        <SkjemaElement>
-                            <RHFValutaInput
-                                name={'loennsinntekt.utland.arbeidsinntektIAar.tilDoedsfall'}
-                                label={t('inntektenDin.loennsinntekt.utland.arbeidsinntektIAar.tilDoedsfall')}
-                                description={t(
-                                    'inntektenDin.loennsinntekt.arbeidsinntektIAar.tilDoedsfall.beskrivelse'
-                                )}
-                                htmlSize={Bredde.S}
-                            />
-                        </SkjemaElement>
-                        {erMellomOktoberogDesember() && (
-                            <SkjemaElement>
+                    {doedsdatoErIAar(datoforDoedsfallet!!) ? (
+                        <>
+                            <SkjemaGruppe>
                                 <RHFValutaInput
-                                    name={'loennsinntekt.utland.arbeidsinntektIAar.etterDoedsfall'}
-                                    label={t('inntektenDin.loennsinntekt.utland.arbeidsinntektIAar.etterDoedsfall')}
+                                    name={'loennsinntekt.utland.arbeidsinntektAaretFoer'}
+                                    label={t('inntektenDin.loennsinntekt.utland.arbeidsinntektAaretFoer')}
+                                    description={t(
+                                        'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.beskrivelse.utland'
+                                    )}
                                     htmlSize={Bredde.S}
                                 />
-                            </SkjemaElement>
-                        )}
-                    </SkjemaGruppe>
+                            </SkjemaGruppe>
+
+                            <SkjemaGruppe>
+                                <SkjemaElement>
+                                    <RHFValutaInput
+                                        name={'loennsinntekt.utland.arbeidsinntektIAar.tilDoedsfall'}
+                                        label={t('inntektenDin.loennsinntekt.utland.arbeidsinntektIAar.tilDoedsfall')}
+                                        description={t(
+                                            'inntektenDin.loennsinntekt.arbeidsinntektIAar.tilDoedsfall.beskrivelse'
+                                        )}
+                                        htmlSize={Bredde.S}
+                                    />
+                                </SkjemaElement>
+                                {erMellomOktoberogDesember() && (
+                                    <SkjemaElement>
+                                        <RHFValutaInput
+                                            name={'loennsinntekt.utland.arbeidsinntektIAar.etterDoedsfall'}
+                                            label={t(
+                                                'inntektenDin.loennsinntekt.utland.arbeidsinntektIAar.etterDoedsfall'
+                                            )}
+                                            htmlSize={Bredde.S}
+                                        />
+                                    </SkjemaElement>
+                                )}
+                            </SkjemaGruppe>
+                        </>
+                    ) : (
+                        <>
+                            <SkjemaGruppe>
+                                <RHFValutaInput
+                                    name={'loennsinntekt.utland.arbeidsinntektAaretFoer'}
+                                    label={t(
+                                        'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer'
+                                    )}
+                                    description={t(
+                                        'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse'
+                                    )}
+                                    htmlSize={Bredde.S}
+                                />
+                            </SkjemaGruppe>
+                            <SkjemaGruppe>
+                                <SkjemaElement>
+                                    <RHFValutaInput
+                                        name={'loennsinntekt.utland.inntektEtterDoedsfall'}
+                                        label={t('inntektenDin.loennsinntekt.inntektEtterDoedsfall')}
+                                        description={t(
+                                            'inntektenDin.loennsinntekt.inntektEtterDoedsfall.beskrivelse'
+                                        )}
+                                        htmlSize={Bredde.S}
+                                    />
+                                </SkjemaElement>
+                                <SkjemaElement>
+                                    <RHFValutaInput
+                                        name={'loennsinntekt.utland.arbeidsinntektIAar.aarsinntekt'}
+                                        label={t('inntektenDin.loennsinntekt.arbeidsinntektIAar.aarsinntekt')}
+                                        description={t(
+                                            'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse'
+                                        )}
+                                        htmlSize={Bredde.S}
+                                    />
+                                </SkjemaElement>
+                            </SkjemaGruppe>
+                        </>
+                    )}
                 </>
             )}
             <Alert variant={'info'}>{t('inntektenDin.loennsinntekt.info')}</Alert>

--- a/apps/omstillingsstoenad-ui/src/components/soknad/6-inntekten-din/fragmenter/Loennsinntekt.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/soknad/6-inntekten-din/fragmenter/Loennsinntekt.tsx
@@ -9,12 +9,16 @@ import EndringInntekt from './EndringInntekt'
 import { RHFCheckboksGruppe } from '../../../felles/rhf/RHFCheckboksPanelGruppe'
 import { IInntekt, NorgeOgUtland } from '../../../../typer/inntekt'
 import { useFormContext } from 'react-hook-form'
-import { erMellomOktoberogDesember } from '../../../../utils/dato'
+import { doedsdatoErIAar, erMellomOktoberogDesember } from '../../../../utils/dato'
+import { useSoknadContext } from '../../../../context/soknad/SoknadContext'
 
 const Loennsinntekt = () => {
     const { t } = useTranslation()
 
     const { watch } = useFormContext<IInntekt>()
+    const { state: soknadState } = useSoknadContext()
+
+    const datoforDoedsfallet = soknadState.omDenAvdoede.datoForDoedsfallet
 
     const norgeEllerUtland = watch('loennsinntekt.norgeEllerUtland')
 
@@ -40,35 +44,78 @@ const Loennsinntekt = () => {
                     <SkjemaElement>
                         <Heading size={'small'}>{t('inntektenDin.loennsinntekt.norgeEllerUtland.norge')}</Heading>
                     </SkjemaElement>
-                    <SkjemaGruppe>
-                        <RHFValutaInput
-                            name={'loennsinntekt.norge.arbeidsinntektAaretFoer'}
-                            label={t('inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer')}
-                            description={t('inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.beskrivelse')}
-                            htmlSize={Bredde.S}
-                        />
-                    </SkjemaGruppe>
-                    <SkjemaGruppe>
-                        <SkjemaElement>
-                            <RHFValutaInput
-                                name={'loennsinntekt.norge.arbeidsinntektIAar.tilDoedsfall'}
-                                label={t('inntektenDin.loennsinntekt.norge.arbeidsinntektIAar.tilDoedsfall')}
-                                description={t(
-                                    'inntektenDin.loennsinntekt.arbeidsinntektIAar.tilDoedsfall.beskrivelse'
-                                )}
-                                htmlSize={Bredde.S}
-                            />
-                        </SkjemaElement>
-                        {erMellomOktoberogDesember() && (
-                            <SkjemaElement>
+                    {doedsdatoErIAar(datoforDoedsfallet!!) ? (
+                        <>
+                            <SkjemaGruppe>
                                 <RHFValutaInput
-                                    name={'loennsinntekt.norge.arbeidsinntektIAar.etterDoedsfall'}
-                                    label={t('inntektenDin.loennsinntekt.norge.arbeidsinntektIAar.etterDoedsfall')}
+                                    name={'loennsinntekt.norge.arbeidsinntektAaretFoer'}
+                                    label={t('inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer')}
+                                    description={t('inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.beskrivelse')}
                                     htmlSize={Bredde.S}
                                 />
-                            </SkjemaElement>
-                        )}
-                    </SkjemaGruppe>
+                            </SkjemaGruppe>
+                            <SkjemaGruppe>
+                                <SkjemaElement>
+                                    <RHFValutaInput
+                                        name={'loennsinntekt.norge.arbeidsinntektIAar.tilDoedsfall'}
+                                        label={t('inntektenDin.loennsinntekt.norge.arbeidsinntektIAar.tilDoedsfall')}
+                                        description={t(
+                                            'inntektenDin.loennsinntekt.arbeidsinntektIAar.tilDoedsfall.beskrivelse'
+                                        )}
+                                        htmlSize={Bredde.S}
+                                    />
+                                </SkjemaElement>
+                                {erMellomOktoberogDesember() && (
+                                    <SkjemaElement>
+                                        <RHFValutaInput
+                                            name={'loennsinntekt.norge.arbeidsinntektIAar.etterDoedsfall'}
+                                            label={t(
+                                                'inntektenDin.loennsinntekt.norge.arbeidsinntektIAar.etterDoedsfall'
+                                            )}
+                                            htmlSize={Bredde.S}
+                                        />
+                                    </SkjemaElement>
+                                )}
+                            </SkjemaGruppe>
+                        </>
+                    ) : (
+                        <>
+                            <SkjemaGruppe>
+                                <RHFValutaInput
+                                    name={'loennsinntekt.norge.arbeidsinntektAaretFoer'}
+                                    label={t(
+                                        'inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer.doedsfallAaretFoer'
+                                    )}
+                                    description={t(
+                                        'inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse'
+                                    )}
+                                    htmlSize={Bredde.S}
+                                />
+                            </SkjemaGruppe>
+                            <SkjemaGruppe>
+                                <SkjemaElement>
+                                    <RHFValutaInput
+                                        name={'loennsinntekt.norge.inntektEtterDoedsfall'}
+                                        label={t('inntektenDin.loennsinntekt.norge.inntektEtterDoedsfall')}
+                                        description={t(
+                                            'inntektenDin.loennsinntekt.norge.inntektEtterDoedsfall.beskrivelse'
+                                        )}
+                                        htmlSize={Bredde.S}
+                                    />
+                                </SkjemaElement>
+                                <SkjemaElement>
+                                    <RHFValutaInput
+                                        name={'loennsinntekt.norge.arbeidsinntektIAar.aarsinntekt'}
+                                        label={t('inntektenDin.loennsinntekt.norge.arbeidsinntektIAar.aarsinntekt')}
+                                        description={t(
+                                            'inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse'
+                                        )}
+                                        htmlSize={Bredde.S}
+                                    />
+                                </SkjemaElement>
+                            </SkjemaGruppe>
+                        </>
+                    )}
                 </>
             )}
 

--- a/apps/omstillingsstoenad-ui/src/components/soknad/6-inntekten-din/fragmenter/Loennsinntekt.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/soknad/6-inntekten-din/fragmenter/Loennsinntekt.tsx
@@ -71,7 +71,7 @@ const Loennsinntekt = () => {
                         <>
                             <SkjemaGruppe>
                                 <RHFValutaInput
-                                    name={'loennsinntekt.norge.arbeidsinntektAaretFoer'}
+                                    name={'loennsinntekt.norge.arbeidsinntektDoedsfallsaaret'}
                                     label={t('inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer')}
                                     description={t(
                                         'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse'
@@ -150,7 +150,7 @@ const Loennsinntekt = () => {
                         <>
                             <SkjemaGruppe>
                                 <RHFValutaInput
-                                    name={'loennsinntekt.utland.arbeidsinntektAaretFoer'}
+                                    name={'loennsinntekt.utland.arbeidsinntektDoedsfallsaaret'}
                                     label={t('inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer')}
                                     description={t(
                                         'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse.utland'

--- a/apps/omstillingsstoenad-ui/src/components/soknad/6-inntekten-din/fragmenter/Naeringsinntekt.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/soknad/6-inntekten-din/fragmenter/Naeringsinntekt.tsx
@@ -11,6 +11,7 @@ import { IInntekt, NorgeOgUtland } from '../../../../typer/inntekt'
 import { RHFCheckboksGruppe } from '../../../felles/rhf/RHFCheckboksPanelGruppe'
 import { doedsdatoErIAar, erMellomOktoberogDesember } from '../../../../utils/dato'
 import { useSoknadContext } from '../../../../context/soknad/SoknadContext'
+import SesongbasertNaeringsinntekt from './SesongbasertNaeringsinntekt'
 
 const Naeringsinntekt = () => {
     const { t } = useTranslation()
@@ -44,74 +45,48 @@ const Naeringsinntekt = () => {
                     <SkjemaElement>
                         <Heading size={'small'}>{t('inntektenDin.naeringsinntekt.norgeEllerUtland.norge')}</Heading>
                     </SkjemaElement>
-                    {doedsdatoErIAar(datoforDoedsfallet!!) ? (
-                        <>
-                            <SkjemaElement>
-                                <RHFValutaInput
-                                    name={'naeringsinntekt.norge.arbeidsinntektAaretFoer'}
-                                    label={t('inntektenDin.naeringsinntekt.norge.arbeidsinntektAaretFoer')}
-                                    description={t('inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.beskrivelse')}
-                                    htmlSize={Bredde.S}
-                                />
-                            </SkjemaElement>
-                            <SkjemaGruppe>
-                                <SkjemaElement>
-                                    <RHFValutaInput
-                                        name={'naeringsinntekt.norge.arbeidsinntektIAar.tilDoedsfall'}
-                                        label={t('inntektenDin.naeringsinntekt.norge.arbeidsinntektIAar.tilDoedsfall')}
-                                        htmlSize={Bredde.S}
-                                    />
-                                </SkjemaElement>
-                                {erMellomOktoberogDesember() && (
-                                    <SkjemaElement>
-                                        <RHFValutaInput
-                                            name={'naeringsinntekt.norge.arbeidsinntektIAar.etterDoedsfall'}
-                                            label={t(
-                                                'inntektenDin.naeringsinntekt.norge.arbeidsinntektIAar.etterDoedsfall'
-                                            )}
-                                            htmlSize={Bredde.S}
-                                        />
-                                    </SkjemaElement>
+                    <SkjemaElement>
+                        <SesongbasertNaeringsinntekt type={'norge'} />
+                    </SkjemaElement>
+                    <SkjemaElement>
+                        <RHFValutaInput
+                            name={'naeringsinntekt.norge.arbeidsinntektAaretFoer'}
+                            label={
+                                doedsdatoErIAar(datoforDoedsfallet!!)
+                                    ? t('inntektenDin.naeringsinntekt.norge.arbeidsinntektAaretFoer')
+                                    : t('inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer')
+                            }
+                            description={
+                                doedsdatoErIAar(datoforDoedsfallet!!)
+                                    ? t('inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.beskrivelse')
+                                    : t(
+                                          'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse'
+                                      )
+                            }
+                            htmlSize={Bredde.S}
+                        />
+                    </SkjemaElement>
+
+                    <SkjemaGruppe>
+                        <SkjemaElement>
+                            <RHFValutaInput
+                                name={'naeringsinntekt.norge.arbeidsinntektIAar.aarsinntekt'}
+                                label={t('inntektenDin.naeringsinntekt.arbeidsinntektIAar.aarsinntekt')}
+                                description={t(
+                                    'inntektenDin.loennsinntekt.arbeidsinntektIAar.aarsinntekt.beskrivelse'
                                 )}
-                            </SkjemaGruppe>
-                        </>
-                    ) : (
-                        <>
-                            <SkjemaElement>
-                                <RHFValutaInput
-                                    name={'naeringsinntekt.norge.arbeidsinntektAaretFoer'}
-                                    label={t(
-                                        'inntektenDin.naeringsinntekt.norge.arbeidsinntektAaretFoer.doedsfallAaretFoer'
-                                    )}
-                                    description={t(
-                                        'inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse'
-                                    )}
-                                    htmlSize={Bredde.S}
-                                />
-                            </SkjemaElement>
-                            <SkjemaGruppe>
-                                <SkjemaElement>
-                                    <RHFValutaInput
-                                        name={'naeringsinntekt.norge.inntektEtterDoedsfall'}
-                                        label={t('inntektenDin.naeringsinntekt.norge.inntektEtterDoedsfall')}
-                                        description={t(
-                                            'inntektenDin.loennsinntekt.norge.inntektEtterDoedsfall.beskrivelse'
-                                        )}
-                                        htmlSize={Bredde.S}
-                                    />
-                                </SkjemaElement>
-                                <SkjemaElement>
-                                    <RHFValutaInput
-                                        name={'naeringsinntekt.norge.arbeidsinntektIAar.aarsinntekt'}
-                                        label={t('inntektenDin.naeringsinntekt.norge.arbeidsinntektIAar.aarsinntekt')}
-                                        description={t(
-                                            'inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse'
-                                        )}
-                                        htmlSize={Bredde.S}
-                                    />
-                                </SkjemaElement>
-                            </SkjemaGruppe>
-                        </>
+                                htmlSize={Bredde.S}
+                            />
+                        </SkjemaElement>
+                    </SkjemaGruppe>
+                    {erMellomOktoberogDesember() && (
+                        <SkjemaGruppe>
+                            <RHFValutaInput
+                                name={'naeringsinntekt.norge.arbeidsinntektIAar.etterDoedsfall'}
+                                label={t('inntektenDin.naeringsinntekt.norge.arbeidsinntektIAar.etterDoedsfall')}
+                                htmlSize={Bredde.S}
+                            />
+                        </SkjemaGruppe>
                     )}
                 </>
             )}
@@ -124,31 +99,47 @@ const Naeringsinntekt = () => {
                         <Heading size={'small'}>{t('inntektenDin.naeringsinntekt.norgeEllerUtland.utland')}</Heading>
                     </SkjemaElement>
                     <SkjemaElement>
+                        <SesongbasertNaeringsinntekt type={'utland'} />
+                    </SkjemaElement>
+                    <SkjemaElement>
                         <RHFValutaInput
                             name={'naeringsinntekt.utland.arbeidsinntektAaretFoer'}
-                            label={t('inntektenDin.naeringsinntekt.utland.arbeidsinntektAaretFoer')}
-                            description={t('inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.beskrivelse.utland')}
+                            label={
+                                doedsdatoErIAar(datoforDoedsfallet!!)
+                                    ? t('inntektenDin.naeringsinntekt.utland.arbeidsinntektAaretFoer')
+                                    : t('inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer')
+                            }
+                            description={
+                                doedsdatoErIAar(datoforDoedsfallet!!)
+                                    ? t('inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.beskrivelse')
+                                    : t(
+                                          'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse'
+                                      )
+                            }
                             htmlSize={Bredde.S}
                         />
                     </SkjemaElement>
                     <SkjemaGruppe>
                         <SkjemaElement>
                             <RHFValutaInput
-                                name={'naeringsinntekt.utland.arbeidsinntektIAar.tilDoedsfall'}
-                                label={t('inntektenDin.naeringsinntekt.utland.arbeidsinntektIAar.tilDoedsfall')}
+                                name={'naeringsinntekt.utland.arbeidsinntektIAar.aarsinntekt'}
+                                label={t('inntektenDin.naeringsinntekt.arbeidsinntektIAar.aarsinntekt')}
+                                description={t(
+                                    'inntektenDin.loennsinntekt.arbeidsinntektIAar.aarsinntekt.beskrivelse'
+                                )}
                                 htmlSize={Bredde.S}
                             />
                         </SkjemaElement>
-                        {erMellomOktoberogDesember() && (
-                            <SkjemaElement>
-                                <RHFValutaInput
-                                    name={'naeringsinntekt.utland.arbeidsinntektIAar.etterDoedsfall'}
-                                    label={t('inntektenDin.naeringsinntekt.utland.arbeidsinntektIAar.etterDoedsfall')}
-                                    htmlSize={Bredde.S}
-                                />
-                            </SkjemaElement>
-                        )}
                     </SkjemaGruppe>
+                    {erMellomOktoberogDesember() && (
+                        <SkjemaGruppe>
+                            <RHFValutaInput
+                                name={'naeringsinntekt.utland.arbeidsinntektIAar.etterDoedsfall'}
+                                label={t('inntektenDin.naeringsinntekt.utland.arbeidsinntektIAar.etterDoedsfall')}
+                                htmlSize={Bredde.S}
+                            />
+                        </SkjemaGruppe>
+                    )}
                 </>
             )}
 

--- a/apps/omstillingsstoenad-ui/src/components/soknad/6-inntekten-din/fragmenter/Naeringsinntekt.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/soknad/6-inntekten-din/fragmenter/Naeringsinntekt.tsx
@@ -9,12 +9,16 @@ import EndringInntekt from './EndringInntekt'
 import { useFormContext } from 'react-hook-form'
 import { IInntekt, NorgeOgUtland } from '../../../../typer/inntekt'
 import { RHFCheckboksGruppe } from '../../../felles/rhf/RHFCheckboksPanelGruppe'
-import { erMellomOktoberogDesember } from '../../../../utils/dato'
+import { doedsdatoErIAar, erMellomOktoberogDesember } from '../../../../utils/dato'
+import { useSoknadContext } from '../../../../context/soknad/SoknadContext'
 
 const Naeringsinntekt = () => {
     const { t } = useTranslation()
 
     const { watch } = useFormContext<IInntekt>()
+    const { state: soknadState } = useSoknadContext()
+
+    const datoforDoedsfallet = soknadState.omDenAvdoede.datoForDoedsfallet
 
     const norgeEllerUtland = watch('naeringsinntekt.norgeEllerUtland')
 
@@ -40,32 +44,75 @@ const Naeringsinntekt = () => {
                     <SkjemaElement>
                         <Heading size={'small'}>{t('inntektenDin.naeringsinntekt.norgeEllerUtland.norge')}</Heading>
                     </SkjemaElement>
-                    <SkjemaElement>
-                        <RHFValutaInput
-                            name={'naeringsinntekt.norge.arbeidsinntektAaretFoer'}
-                            label={t('inntektenDin.naeringsinntekt.norge.arbeidsinntektAaretFoer')}
-                            description={t('inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.beskrivelse')}
-                            htmlSize={Bredde.S}
-                        />
-                    </SkjemaElement>
-                    <SkjemaGruppe>
-                        <SkjemaElement>
-                            <RHFValutaInput
-                                name={'naeringsinntekt.norge.arbeidsinntektIAar.tilDoedsfall'}
-                                label={t('inntektenDin.naeringsinntekt.norge.arbeidsinntektIAar.tilDoedsfall')}
-                                htmlSize={Bredde.S}
-                            />
-                        </SkjemaElement>
-                        {erMellomOktoberogDesember() && (
+                    {doedsdatoErIAar(datoforDoedsfallet!!) ? (
+                        <>
                             <SkjemaElement>
                                 <RHFValutaInput
-                                    name={'naeringsinntekt.norge.arbeidsinntektIAar.etterDoedsfall'}
-                                    label={t('inntektenDin.naeringsinntekt.norge.arbeidsinntektIAar.etterDoedsfall')}
+                                    name={'naeringsinntekt.norge.arbeidsinntektAaretFoer'}
+                                    label={t('inntektenDin.naeringsinntekt.norge.arbeidsinntektAaretFoer')}
+                                    description={t('inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.beskrivelse')}
                                     htmlSize={Bredde.S}
                                 />
                             </SkjemaElement>
-                        )}
-                    </SkjemaGruppe>
+                            <SkjemaGruppe>
+                                <SkjemaElement>
+                                    <RHFValutaInput
+                                        name={'naeringsinntekt.norge.arbeidsinntektIAar.tilDoedsfall'}
+                                        label={t('inntektenDin.naeringsinntekt.norge.arbeidsinntektIAar.tilDoedsfall')}
+                                        htmlSize={Bredde.S}
+                                    />
+                                </SkjemaElement>
+                                {erMellomOktoberogDesember() && (
+                                    <SkjemaElement>
+                                        <RHFValutaInput
+                                            name={'naeringsinntekt.norge.arbeidsinntektIAar.etterDoedsfall'}
+                                            label={t(
+                                                'inntektenDin.naeringsinntekt.norge.arbeidsinntektIAar.etterDoedsfall'
+                                            )}
+                                            htmlSize={Bredde.S}
+                                        />
+                                    </SkjemaElement>
+                                )}
+                            </SkjemaGruppe>
+                        </>
+                    ) : (
+                        <>
+                            <SkjemaElement>
+                                <RHFValutaInput
+                                    name={'naeringsinntekt.norge.arbeidsinntektAaretFoer'}
+                                    label={t(
+                                        'inntektenDin.naeringsinntekt.norge.arbeidsinntektAaretFoer.doedsfallAaretFoer'
+                                    )}
+                                    description={t(
+                                        'inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse'
+                                    )}
+                                    htmlSize={Bredde.S}
+                                />
+                            </SkjemaElement>
+                            <SkjemaGruppe>
+                                <SkjemaElement>
+                                    <RHFValutaInput
+                                        name={'naeringsinntekt.norge.inntektEtterDoedsfall'}
+                                        label={t('inntektenDin.naeringsinntekt.norge.inntektEtterDoedsfall')}
+                                        description={t(
+                                            'inntektenDin.loennsinntekt.norge.inntektEtterDoedsfall.beskrivelse'
+                                        )}
+                                        htmlSize={Bredde.S}
+                                    />
+                                </SkjemaElement>
+                                <SkjemaElement>
+                                    <RHFValutaInput
+                                        name={'naeringsinntekt.norge.arbeidsinntektIAar.aarsinntekt'}
+                                        label={t('inntektenDin.naeringsinntekt.norge.arbeidsinntektIAar.aarsinntekt')}
+                                        description={t(
+                                            'inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse'
+                                        )}
+                                        htmlSize={Bredde.S}
+                                    />
+                                </SkjemaElement>
+                            </SkjemaGruppe>
+                        </>
+                    )}
                 </>
             )}
 

--- a/apps/omstillingsstoenad-ui/src/components/soknad/6-inntekten-din/fragmenter/Naeringsinntekt.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/soknad/6-inntekten-din/fragmenter/Naeringsinntekt.tsx
@@ -60,7 +60,7 @@ const Naeringsinntekt = () => {
                                 doedsdatoErIAar(datoforDoedsfallet!!)
                                     ? t('inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.beskrivelse')
                                     : t(
-                                          'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse'
+                                          'inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse'
                                       )
                             }
                             htmlSize={Bredde.S}
@@ -72,9 +72,7 @@ const Naeringsinntekt = () => {
                             <RHFValutaInput
                                 name={'naeringsinntekt.norge.arbeidsinntektIAar.aarsinntekt'}
                                 label={t('inntektenDin.naeringsinntekt.arbeidsinntektIAar.aarsinntekt')}
-                                description={t(
-                                    'inntektenDin.loennsinntekt.arbeidsinntektIAar.aarsinntekt.beskrivelse'
-                                )}
+                                description={t('inntektenDin.loennsinntekt.arbeidsinntektIAar.aarsinntekt.beskrivelse')}
                                 htmlSize={Bredde.S}
                             />
                         </SkjemaElement>
@@ -109,13 +107,7 @@ const Naeringsinntekt = () => {
                                     ? t('inntektenDin.naeringsinntekt.utland.arbeidsinntektAaretFoer')
                                     : t('inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer')
                             }
-                            description={
-                                doedsdatoErIAar(datoforDoedsfallet!!)
-                                    ? t('inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.beskrivelse')
-                                    : t(
-                                          'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse'
-                                      )
-                            }
+                            description={t('inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.beskrivelse.utland')}
                             htmlSize={Bredde.S}
                         />
                     </SkjemaElement>
@@ -124,9 +116,7 @@ const Naeringsinntekt = () => {
                             <RHFValutaInput
                                 name={'naeringsinntekt.utland.arbeidsinntektIAar.aarsinntekt'}
                                 label={t('inntektenDin.naeringsinntekt.arbeidsinntektIAar.aarsinntekt')}
-                                description={t(
-                                    'inntektenDin.loennsinntekt.arbeidsinntektIAar.aarsinntekt.beskrivelse'
-                                )}
+                                description={t('inntektenDin.loennsinntekt.arbeidsinntektIAar.aarsinntekt.beskrivelse')}
                                 htmlSize={Bredde.S}
                             />
                         </SkjemaElement>

--- a/apps/omstillingsstoenad-ui/src/components/soknad/6-inntekten-din/fragmenter/Naeringsinntekt.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/soknad/6-inntekten-din/fragmenter/Naeringsinntekt.tsx
@@ -49,22 +49,23 @@ const Naeringsinntekt = () => {
                         <SesongbasertNaeringsinntekt type={'norge'} />
                     </SkjemaElement>
                     <SkjemaElement>
-                        <RHFValutaInput
-                            name={'naeringsinntekt.norge.arbeidsinntektAaretFoer'}
-                            label={
-                                doedsdatoErIAar(datoforDoedsfallet!!)
-                                    ? t('inntektenDin.naeringsinntekt.norge.arbeidsinntektAaretFoer')
-                                    : t('inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer')
-                            }
-                            description={
-                                doedsdatoErIAar(datoforDoedsfallet!!)
-                                    ? t('inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.beskrivelse')
-                                    : t(
-                                          'inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse'
-                                      )
-                            }
-                            htmlSize={Bredde.S}
-                        />
+                        {doedsdatoErIAar(datoforDoedsfallet!!) ? (
+                            <RHFValutaInput
+                                name={'naeringsinntekt.norge.arbeidsinntektAaretFoer'}
+                                label={t('inntektenDin.naeringsinntekt.norge.arbeidsinntektAaretFoer')}
+                                description={t('inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.beskrivelse')}
+                                htmlSize={Bredde.S}
+                            />
+                        ) : (
+                            <RHFValutaInput
+                                name={'naeringsinntekt.norge.arbeidsinntektDoedsfallsaaret'}
+                                label={t('inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer')}
+                                description={t(
+                                    'inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse'
+                                )}
+                                htmlSize={Bredde.S}
+                            />
+                        )}
                     </SkjemaElement>
 
                     <SkjemaGruppe>
@@ -100,16 +101,25 @@ const Naeringsinntekt = () => {
                         <SesongbasertNaeringsinntekt type={'utland'} />
                     </SkjemaElement>
                     <SkjemaElement>
-                        <RHFValutaInput
-                            name={'naeringsinntekt.utland.arbeidsinntektAaretFoer'}
-                            label={
-                                doedsdatoErIAar(datoforDoedsfallet!!)
-                                    ? t('inntektenDin.naeringsinntekt.utland.arbeidsinntektAaretFoer')
-                                    : t('inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer')
-                            }
-                            description={t('inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.beskrivelse.utland')}
-                            htmlSize={Bredde.S}
-                        />
+                        {doedsdatoErIAar(datoforDoedsfallet!!) ? (
+                            <RHFValutaInput
+                                name={'naeringsinntekt.utland.arbeidsinntektAaretFoer'}
+                                label={t('inntektenDin.naeringsinntekt.utland.arbeidsinntektAaretFoer')}
+                                description={t(
+                                    'inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.beskrivelse.utland'
+                                )}
+                                htmlSize={Bredde.S}
+                            />
+                        ) : (
+                            <RHFValutaInput
+                                name={'naeringsinntekt.utland.arbeidsinntektDoedsfallsaaret'}
+                                label={t('inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer')}
+                                description={t(
+                                    'inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.beskrivelse.utland'
+                                )}
+                                htmlSize={Bredde.S}
+                            />
+                        )}
                     </SkjemaElement>
                     <SkjemaGruppe>
                         <SkjemaElement>

--- a/apps/omstillingsstoenad-ui/src/components/soknad/6-inntekten-din/fragmenter/SesongbasertNaeringsinntekt.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/soknad/6-inntekten-din/fragmenter/SesongbasertNaeringsinntekt.tsx
@@ -1,0 +1,44 @@
+import { useTranslation } from 'react-i18next'
+import React from 'react'
+import { useFormContext } from 'react-hook-form'
+import { SkjemaElement } from '../../../felles/SkjemaElement'
+import { RHFSpoersmaalRadio } from '../../../felles/rhf/RHFRadio'
+import { IValg } from '../../../../typer/Spoersmaal'
+import { RHFInputArea } from '../../../felles/rhf/RHFInput'
+
+interface Props {
+    type: 'norge' | 'utland'
+}
+
+const SesongbasertNaeringsinntekt = ({ type }: Props) => {
+    const { t } = useTranslation()
+
+    const { watch } = useFormContext()
+
+    const baseUrl = `naeringsinntekt.${type}.sesongbasertNaeringsinntekt`
+
+    const endrerInntekt = watch(`${baseUrl}.svar`)
+
+    return (
+        <>
+            <SkjemaElement>
+                <RHFSpoersmaalRadio
+                    name={`${baseUrl}.svar`}
+                    legend={t('inntektenDin.naeringsinntekt.sesongbasertNaeringsinntekt.svar')}
+                />
+            </SkjemaElement>
+            {endrerInntekt === IValg.JA && (
+                <SkjemaElement>
+                    <RHFInputArea
+                        name={`${baseUrl}.beskrivelse`}
+                        label={t('inntektenDin.naeringsinntekt.sesongbasertNaeringsinntekt.beskrivelse')}
+                        maxLength={200}
+                        className={'width-50'}
+                    />
+                </SkjemaElement>
+            )}
+        </>
+    )
+}
+
+export default SesongbasertNaeringsinntekt

--- a/apps/omstillingsstoenad-ui/src/components/soknad/6-inntekten-din/fragmenter/SesongbasertNaeringsinntekt.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/soknad/6-inntekten-din/fragmenter/SesongbasertNaeringsinntekt.tsx
@@ -25,6 +25,7 @@ const SesongbasertNaeringsinntekt = ({ type }: Props) => {
                 <RHFSpoersmaalRadio
                     name={`${baseUrl}.svar`}
                     legend={t('inntektenDin.naeringsinntekt.sesongbasertNaeringsinntekt.svar')}
+                    description={t('inntektenDin.naeringsinntekt.sesongbasertNaeringsinntekt.svar.beskrivelse')}
                 />
             </SkjemaElement>
             {endrerInntekt === IValg.JA && (

--- a/apps/omstillingsstoenad-ui/src/components/soknad/8-oppsummering/Oppsummering.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/soknad/8-oppsummering/Oppsummering.tsx
@@ -84,7 +84,11 @@ const Oppsummering: SoknadSteg = ({ forrige }) => {
                     merOmSituasjonenDin={soeknad.merOmSituasjonenDin}
                     senderSoeknad={senderSoeknad}
                 />
-                <OppsummeringInntektenDin inntektenDin={soeknad.inntektenDin} senderSoeknad={senderSoeknad} />
+                <OppsummeringInntektenDin
+                    inntektenDin={soeknad.inntektenDin}
+                    senderSoeknad={senderSoeknad}
+                    datoforDoedsfallet={soeknad.omDenAvdoede.datoForDoedsfallet!!}
+                />
                 <OppsummeringBarnepensjon
                     opplysningerOmBarn={soeknad.opplysningerOmBarn}
                     senderSoeknad={senderSoeknad}

--- a/apps/omstillingsstoenad-ui/src/components/soknad/8-oppsummering/fragmenter/OppsummeringInntektenDin.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/soknad/8-oppsummering/fragmenter/OppsummeringInntektenDin.tsx
@@ -13,14 +13,18 @@ import {
     PensjonEllerTrygd,
 } from '../../../../typer/inntekt'
 import { IValg } from '../../../../typer/Spoersmaal'
+import { doedsdatoErIAar } from '../../../../utils/dato'
 
 interface Props {
     inntektenDin: IInntekt
     senderSoeknad: boolean
+    datoforDoedsfallet: Date
 }
 
-export const OppsummeringInntektenDin = memo(({ inntektenDin, senderSoeknad }: Props) => {
+export const OppsummeringInntektenDin = memo(({ inntektenDin, senderSoeknad, datoforDoedsfallet }: Props) => {
     const { t } = useTranslation()
+
+    const doedsfallIAar = doedsdatoErIAar(datoforDoedsfallet!!)
 
     return (
         <AccordionItem
@@ -50,19 +54,43 @@ export const OppsummeringInntektenDin = memo(({ inntektenDin, senderSoeknad }: P
                             <Heading size={'xsmall'}>{t('inntektenDin.loennsinntekt.norgeEllerUtland.norge')}</Heading>
 
                             <TekstGruppe
-                                tittel={t('inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer')}
+                                tittel={
+                                    doedsfallIAar
+                                        ? t('inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer')
+                                        : t('inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer')
+                                }
                                 innhold={inntektenDin.loennsinntekt.norge?.arbeidsinntektAaretFoer}
                             />
-                            <TekstGruppe
-                                tittel={t('inntektenDin.loennsinntekt.norge.arbeidsinntektIAar.tilDoedsfall')}
-                                innhold={inntektenDin.loennsinntekt.norge?.arbeidsinntektIAar?.tilDoedsfall}
-                            />
+                            {doedsfallIAar ? (
+                                <>
+                                    <TekstGruppe
+                                        tittel={t('inntektenDin.loennsinntekt.norge.arbeidsinntektIAar.tilDoedsfall')}
+                                        innhold={inntektenDin.loennsinntekt.norge?.arbeidsinntektIAar?.tilDoedsfall}
+                                    />
 
-                            {inntektenDin.loennsinntekt.norge?.arbeidsinntektIAar?.etterDoedsfall && (
-                                <TekstGruppe
-                                    tittel={t('inntektenDin.loennsinntekt.norge.arbeidsinntektIAar.etterDoedsfall')}
-                                    innhold={inntektenDin.loennsinntekt.norge?.arbeidsinntektIAar?.etterDoedsfall}
-                                />
+                                    {inntektenDin.loennsinntekt.norge?.arbeidsinntektIAar?.etterDoedsfall && (
+                                        <TekstGruppe
+                                            tittel={t(
+                                                'inntektenDin.loennsinntekt.norge.arbeidsinntektIAar.etterDoedsfall'
+                                            )}
+                                            innhold={
+                                                inntektenDin.loennsinntekt.norge?.arbeidsinntektIAar?.etterDoedsfall
+                                            }
+                                        />
+                                    )}
+                                </>
+                            ) : (
+                                <>
+                                    <TekstGruppe
+                                        tittel={t('inntektenDin.loennsinntekt.inntektEtterDoedsfall')}
+                                        innhold={inntektenDin.loennsinntekt.norge?.inntektEtterDoedsfall}
+                                    />
+
+                                    <TekstGruppe
+                                        tittel={t('inntektenDin.loennsinntekt.arbeidsinntektIAar.aarsinntekt')}
+                                        innhold={inntektenDin.loennsinntekt.norge?.arbeidsinntektIAar?.aarsinntekt}
+                                    />
+                                </>
                             )}
                         </Panel>
                     )}
@@ -72,19 +100,44 @@ export const OppsummeringInntektenDin = memo(({ inntektenDin, senderSoeknad }: P
                             <Heading size={'xsmall'}>{t('inntektenDin.loennsinntekt.norgeEllerUtland.utland')}</Heading>
 
                             <TekstGruppe
-                                tittel={t('inntektenDin.loennsinntekt.utland.arbeidsinntektAaretFoer')}
+                                tittel={
+                                    doedsfallIAar
+                                        ? t('inntektenDin.loennsinntekt.utland.arbeidsinntektAaretFoer')
+                                        : t('inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer')
+                                }
                                 innhold={inntektenDin.loennsinntekt.utland?.arbeidsinntektAaretFoer}
                             />
-                            <TekstGruppe
-                                tittel={t('inntektenDin.loennsinntekt.utland.arbeidsinntektIAar.tilDoedsfall')}
-                                innhold={inntektenDin.loennsinntekt.utland?.arbeidsinntektIAar?.tilDoedsfall}
-                            />
 
-                            {inntektenDin.loennsinntekt.utland?.arbeidsinntektIAar?.etterDoedsfall && (
-                                <TekstGruppe
-                                    tittel={t('inntektenDin.loennsinntekt.utland.arbeidsinntektIAar.etterDoedsfall')}
-                                    innhold={inntektenDin.loennsinntekt.utland?.arbeidsinntektIAar?.etterDoedsfall}
-                                />
+                            {doedsfallIAar ? (
+                                <>
+                                    <TekstGruppe
+                                        tittel={t('inntektenDin.loennsinntekt.utland.arbeidsinntektIAar.tilDoedsfall')}
+                                        innhold={inntektenDin.loennsinntekt.utland?.arbeidsinntektIAar?.tilDoedsfall}
+                                    />
+
+                                    {inntektenDin.loennsinntekt.utland?.arbeidsinntektIAar?.etterDoedsfall && (
+                                        <TekstGruppe
+                                            tittel={t(
+                                                'inntektenDin.loennsinntekt.utland.arbeidsinntektIAar.etterDoedsfall'
+                                            )}
+                                            innhold={
+                                                inntektenDin.loennsinntekt.utland?.arbeidsinntektIAar?.etterDoedsfall
+                                            }
+                                        />
+                                    )}
+                                </>
+                            ) : (
+                                <>
+                                    <TekstGruppe
+                                        tittel={t('inntektenDin.loennsinntekt.inntektEtterDoedsfall')}
+                                        innhold={inntektenDin.loennsinntekt.utland?.inntektEtterDoedsfall}
+                                    />
+
+                                    <TekstGruppe
+                                        tittel={t('inntektenDin.loennsinntekt.arbeidsinntektIAar.aarsinntekt')}
+                                        innhold={inntektenDin.loennsinntekt.utland?.arbeidsinntektIAar?.aarsinntekt}
+                                    />
+                                </>
                             )}
                         </Panel>
                     )}

--- a/apps/omstillingsstoenad-ui/src/components/soknad/8-oppsummering/fragmenter/OppsummeringInntektenDin.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/soknad/8-oppsummering/fragmenter/OppsummeringInntektenDin.tsx
@@ -183,15 +183,6 @@ export const OppsummeringInntektenDin = memo(({ inntektenDin, senderSoeknad, dat
                                 {t('inntektenDin.naeringsinntekt.norgeEllerUtland.norge')}
                             </Heading>
 
-                            <TekstGruppe
-                                tittel={t('inntektenDin.naeringsinntekt.norge.arbeidsinntektAaretFoer')}
-                                innhold={inntektenDin.naeringsinntekt.norge?.arbeidsinntektAaretFoer}
-                            />
-                            <TekstGruppe
-                                tittel={t('inntektenDin.naeringsinntekt.arbeidsinntektIAar.aarsinntekt')}
-                                innhold={inntektenDin.naeringsinntekt.norge?.arbeidsinntektIAar?.aarsinntekt}
-                            />
-
                             <TekstGruppeJaNeiVetIkke
                                 tittel={t('inntektenDin.naeringsinntekt.sesongbasertNaeringsinntekt.svar')}
                                 innhold={inntektenDin.naeringsinntekt?.norge?.sesongbasertNaeringsinntekt?.svar}
@@ -205,6 +196,24 @@ export const OppsummeringInntektenDin = memo(({ inntektenDin, senderSoeknad, dat
                                     }
                                 />
                             )}
+
+                            {doedsfallIAar ? (
+                                <TekstGruppe
+                                    tittel={t('inntektenDin.naeringsinntekt.norge.arbeidsinntektAaretFoer')}
+                                    innhold={inntektenDin.naeringsinntekt.norge?.arbeidsinntektAaretFoer}
+                                />
+                            ) : (
+                                <TekstGruppe
+                                    tittel={t(
+                                        'inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer'
+                                    )}
+                                    innhold={inntektenDin.naeringsinntekt.norge?.arbeidsinntektDoedsfallsaaret}
+                                />
+                            )}
+                            <TekstGruppe
+                                tittel={t('inntektenDin.naeringsinntekt.arbeidsinntektIAar.aarsinntekt')}
+                                innhold={inntektenDin.naeringsinntekt.norge?.arbeidsinntektIAar?.aarsinntekt}
+                            />
 
                             {inntektenDin.naeringsinntekt.norge?.arbeidsinntektIAar?.etterDoedsfall && (
                                 <TekstGruppe
@@ -221,15 +230,6 @@ export const OppsummeringInntektenDin = memo(({ inntektenDin, senderSoeknad, dat
                                 {t('inntektenDin.naeringsinntekt.norgeEllerUtland.utland')}
                             </Heading>
 
-                            <TekstGruppe
-                                tittel={t('inntektenDin.naeringsinntekt.utland.arbeidsinntektAaretFoer')}
-                                innhold={inntektenDin.naeringsinntekt.utland?.arbeidsinntektAaretFoer}
-                            />
-                            <TekstGruppe
-                                tittel={t('inntektenDin.naeringsinntekt.arbeidsinntektIAar.aarsinntekt')}
-                                innhold={inntektenDin.naeringsinntekt.utland?.arbeidsinntektIAar?.aarsinntekt}
-                            />
-
                             <TekstGruppeJaNeiVetIkke
                                 tittel={t('inntektenDin.naeringsinntekt.sesongbasertNaeringsinntekt.svar')}
                                 innhold={inntektenDin.naeringsinntekt?.utland?.sesongbasertNaeringsinntekt?.svar}
@@ -243,6 +243,25 @@ export const OppsummeringInntektenDin = memo(({ inntektenDin, senderSoeknad, dat
                                     }
                                 />
                             )}
+
+                            {doedsfallIAar ? (
+                                <TekstGruppe
+                                    tittel={t('inntektenDin.naeringsinntekt.utland.arbeidsinntektAaretFoer')}
+                                    innhold={inntektenDin.naeringsinntekt.utland?.arbeidsinntektAaretFoer}
+                                />
+                            ) : (
+                                <TekstGruppe
+                                    tittel={t(
+                                        'inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer'
+                                    )}
+                                    innhold={inntektenDin.naeringsinntekt.utland?.arbeidsinntektDoedsfallsaaret}
+                                />
+                            )}
+
+                            <TekstGruppe
+                                tittel={t('inntektenDin.naeringsinntekt.arbeidsinntektIAar.aarsinntekt')}
+                                innhold={inntektenDin.naeringsinntekt.utland?.arbeidsinntektIAar?.aarsinntekt}
+                            />
 
                             {inntektenDin.naeringsinntekt.utland?.arbeidsinntektIAar?.etterDoedsfall && (
                                 <TekstGruppe

--- a/apps/omstillingsstoenad-ui/src/components/soknad/8-oppsummering/fragmenter/OppsummeringInntektenDin.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/soknad/8-oppsummering/fragmenter/OppsummeringInntektenDin.tsx
@@ -53,16 +53,12 @@ export const OppsummeringInntektenDin = memo(({ inntektenDin, senderSoeknad, dat
                         <Panel>
                             <Heading size={'xsmall'}>{t('inntektenDin.loennsinntekt.norgeEllerUtland.norge')}</Heading>
 
-                            <TekstGruppe
-                                tittel={
-                                    doedsfallIAar
-                                        ? t('inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer')
-                                        : t('inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer')
-                                }
-                                innhold={inntektenDin.loennsinntekt.norge?.arbeidsinntektAaretFoer}
-                            />
                             {doedsfallIAar ? (
                                 <>
+                                    <TekstGruppe
+                                        tittel={t('inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer')}
+                                        innhold={inntektenDin.loennsinntekt.norge?.arbeidsinntektAaretFoer}
+                                    />
                                     <TekstGruppe
                                         tittel={t('inntektenDin.loennsinntekt.norge.arbeidsinntektIAar.tilDoedsfall')}
                                         innhold={inntektenDin.loennsinntekt.norge?.arbeidsinntektIAar?.tilDoedsfall}
@@ -82,6 +78,12 @@ export const OppsummeringInntektenDin = memo(({ inntektenDin, senderSoeknad, dat
                             ) : (
                                 <>
                                     <TekstGruppe
+                                        tittel={t(
+                                            'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer'
+                                        )}
+                                        innhold={inntektenDin.loennsinntekt.norge?.arbeidsinntektDoedsfallsaaret}
+                                    />
+                                    <TekstGruppe
                                         tittel={t('inntektenDin.loennsinntekt.inntektEtterDoedsfall')}
                                         innhold={inntektenDin.loennsinntekt.norge?.inntektEtterDoedsfall}
                                     />
@@ -99,17 +101,12 @@ export const OppsummeringInntektenDin = memo(({ inntektenDin, senderSoeknad, dat
                         <Panel>
                             <Heading size={'xsmall'}>{t('inntektenDin.loennsinntekt.norgeEllerUtland.utland')}</Heading>
 
-                            <TekstGruppe
-                                tittel={
-                                    doedsfallIAar
-                                        ? t('inntektenDin.loennsinntekt.utland.arbeidsinntektAaretFoer')
-                                        : t('inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer')
-                                }
-                                innhold={inntektenDin.loennsinntekt.utland?.arbeidsinntektAaretFoer}
-                            />
-
                             {doedsfallIAar ? (
                                 <>
+                                    <TekstGruppe
+                                        tittel={t('inntektenDin.loennsinntekt.utland.arbeidsinntektAaretFoer')}
+                                        innhold={inntektenDin.loennsinntekt.utland?.arbeidsinntektAaretFoer}
+                                    />
                                     <TekstGruppe
                                         tittel={t('inntektenDin.loennsinntekt.utland.arbeidsinntektIAar.tilDoedsfall')}
                                         innhold={inntektenDin.loennsinntekt.utland?.arbeidsinntektIAar?.tilDoedsfall}
@@ -128,6 +125,12 @@ export const OppsummeringInntektenDin = memo(({ inntektenDin, senderSoeknad, dat
                                 </>
                             ) : (
                                 <>
+                                    <TekstGruppe
+                                        tittel={t(
+                                            'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer'
+                                        )}
+                                        innhold={inntektenDin.loennsinntekt.utland?.arbeidsinntektDoedsfallsaaret}
+                                    />
                                     <TekstGruppe
                                         tittel={t('inntektenDin.loennsinntekt.inntektEtterDoedsfall')}
                                         innhold={inntektenDin.loennsinntekt.utland?.inntektEtterDoedsfall}

--- a/apps/omstillingsstoenad-ui/src/components/soknad/8-oppsummering/fragmenter/OppsummeringInntektenDin.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/soknad/8-oppsummering/fragmenter/OppsummeringInntektenDin.tsx
@@ -185,9 +185,23 @@ export const OppsummeringInntektenDin = memo(({ inntektenDin, senderSoeknad, dat
                                 innhold={inntektenDin.naeringsinntekt.norge?.arbeidsinntektAaretFoer}
                             />
                             <TekstGruppe
-                                tittel={t('inntektenDin.naeringsinntekt.norge.arbeidsinntektIAar.tilDoedsfall')}
-                                innhold={inntektenDin.naeringsinntekt.norge?.arbeidsinntektIAar?.tilDoedsfall}
+                                tittel={t('inntektenDin.naeringsinntekt.arbeidsinntektIAar.aarsinntekt')}
+                                innhold={inntektenDin.naeringsinntekt.norge?.arbeidsinntektIAar?.aarsinntekt}
                             />
+
+                            <TekstGruppeJaNeiVetIkke
+                                tittel={t('inntektenDin.naeringsinntekt.sesongbasertNaeringsinntekt.svar')}
+                                innhold={inntektenDin.naeringsinntekt?.norge?.sesongbasertNaeringsinntekt?.svar}
+                            />
+
+                            {inntektenDin.naeringsinntekt?.norge?.sesongbasertNaeringsinntekt?.svar === IValg.JA && (
+                                <TekstGruppe
+                                    tittel={t('inntektenDin.naeringsinntekt.sesongbasertNaeringsinntekt.beskrivelse')}
+                                    innhold={
+                                        inntektenDin.naeringsinntekt?.norge?.sesongbasertNaeringsinntekt?.beskrivelse
+                                    }
+                                />
+                            )}
 
                             {inntektenDin.naeringsinntekt.norge?.arbeidsinntektIAar?.etterDoedsfall && (
                                 <TekstGruppe
@@ -209,9 +223,23 @@ export const OppsummeringInntektenDin = memo(({ inntektenDin, senderSoeknad, dat
                                 innhold={inntektenDin.naeringsinntekt.utland?.arbeidsinntektAaretFoer}
                             />
                             <TekstGruppe
-                                tittel={t('inntektenDin.naeringsinntekt.utland.arbeidsinntektIAar.tilDoedsfall')}
-                                innhold={inntektenDin.naeringsinntekt.utland?.arbeidsinntektIAar?.tilDoedsfall}
+                                tittel={t('inntektenDin.naeringsinntekt.arbeidsinntektIAar.aarsinntekt')}
+                                innhold={inntektenDin.naeringsinntekt.utland?.arbeidsinntektIAar?.aarsinntekt}
                             />
+
+                            <TekstGruppeJaNeiVetIkke
+                                tittel={t('inntektenDin.naeringsinntekt.sesongbasertNaeringsinntekt.svar')}
+                                innhold={inntektenDin.naeringsinntekt?.utland?.sesongbasertNaeringsinntekt?.svar}
+                            />
+
+                            {inntektenDin.naeringsinntekt?.utland?.sesongbasertNaeringsinntekt?.svar === IValg.JA && (
+                                <TekstGruppe
+                                    tittel={t('inntektenDin.naeringsinntekt.sesongbasertNaeringsinntekt.beskrivelse')}
+                                    innhold={
+                                        inntektenDin.naeringsinntekt?.utland?.sesongbasertNaeringsinntekt?.beskrivelse
+                                    }
+                                />
+                            )}
 
                             {inntektenDin.naeringsinntekt.utland?.arbeidsinntektIAar?.etterDoedsfall && (
                                 <TekstGruppe

--- a/apps/omstillingsstoenad-ui/src/locales/en.ts
+++ b/apps/omstillingsstoenad-ui/src/locales/en.ts
@@ -282,10 +282,10 @@ export default {
     'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse':
         'If the Norwegian Tax Administration has not published your income and tax figures for that year, please state the annual income shown on your pay slip for December for that year.',
     'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse.utland':
-        'If the Norwegian Tax Administration has not published your income for that year, please estimate your business income for that year.',
+        'If you do not know your income for this year, you can state the annual income shown on your pay slip for December.',
     'inntektenDin.loennsinntekt.inntektEtterDoedsfall': 'What was your income after the death?',
     'inntektenDin.loennsinntekt.inntektEtterDoedsfall.beskrivelse':
-        'From the month after the death and up to and including december that year. If the death was in December, Hvis dødsfallmåneden var desember, state 0 kroner.',
+        'Please state from the month after the death until the end of December for that year. If the month of death was December, please enter 0 kroner.',
     'inntektenDin.loennsinntekt.utland.arbeidsinntektAaretFoer':
         'What was your gross annual income in the year before the death?',
     'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.beskrivelse':
@@ -325,7 +325,7 @@ export default {
     'inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer':
         'What was your gross annual business income in the year of the death?',
     'inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse':
-        ' If the Norwegian Tax Administration has not published your income for that year, please estimate your business income for that year.',
+        'If the Norwegian Tax Administration has not published your income for that year, please estimate your business income for that year.',
     'inntektenDin.naeringsinntekt.norge.inntektEtterDoedsfall': 'What was your income after the death?',
     'inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.beskrivelse':
         'If the Norwegian Tax Administration has not published your income for that year, please estimate your business income for that year.',

--- a/apps/omstillingsstoenad-ui/src/locales/en.ts
+++ b/apps/omstillingsstoenad-ui/src/locales/en.ts
@@ -277,12 +277,12 @@ export default {
     'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.tittel': 'Your income from work before the death',
     'inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer':
         'What was your gross annual income in the year before the death?',
-    'inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer.doedsfallAaretFoer':
+    'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer':
         'What was your gross annual income in the year of the death?',
-    'inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse':
+    'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse':
         'From january and up to and including december',
-    'inntektenDin.loennsinntekt.norge.inntektEtterDoedsfall': 'What was your income after the death?',
-    'inntektenDin.loennsinntekt.norge.inntektEtterDoedsfall.beskrivelse':
+    'inntektenDin.loennsinntekt.inntektEtterDoedsfall': 'What was your income after the death?',
+    'inntektenDin.loennsinntekt.inntektEtterDoedsfall.beskrivelse':
         'From the month after the death and up to and including december that year. If the death was in December, Hvis dødsfallmåneden var desember, state 0 kroner.',
     'inntektenDin.loennsinntekt.utland.arbeidsinntektAaretFoer':
         'What was your gross annual income in the year before the death?',
@@ -300,7 +300,7 @@ export default {
         'What do you expect to earn in gross annual income for next year?',
     'inntektenDin.loennsinntekt.utland.arbeidsinntektIAar.etterDoedsfall':
         'What do you expect to earn in gross annual income for next year?',
-    'inntektenDin.loennsinntekt.norge.arbeidsinntektIAar.aarsinntekt':
+    'inntektenDin.loennsinntekt.arbeidsinntektIAar.aarsinntekt':
         'What do you expect to earn in gross annual income this year?',
     'inntektenDin.loennsinntekt.forventerEndringAvInntekt.svar':
         'Do you expect your income to change in the near future?',

--- a/apps/omstillingsstoenad-ui/src/locales/en.ts
+++ b/apps/omstillingsstoenad-ui/src/locales/en.ts
@@ -281,6 +281,8 @@ export default {
         'What was your gross annual income in the year of the death?',
     'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse':
         'If the Norwegian Tax Administration has not published your income and tax figures for that year, please state the annual income shown on your pay slip for December for that year.',
+    'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse.utland':
+        'If the Norwegian Tax Administration has not published your income for that year, please estimate your business income for that year.',
     'inntektenDin.loennsinntekt.inntektEtterDoedsfall': 'What was your income after the death?',
     'inntektenDin.loennsinntekt.inntektEtterDoedsfall.beskrivelse':
         'From the month after the death and up to and including december that year. If the death was in December, Hvis dødsfallmåneden var desember, state 0 kroner.',

--- a/apps/omstillingsstoenad-ui/src/locales/en.ts
+++ b/apps/omstillingsstoenad-ui/src/locales/en.ts
@@ -280,7 +280,7 @@ export default {
     'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer':
         'What was your gross annual income in the year of the death?',
     'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse':
-        'Please state from January to end of December.',
+        'If the Norwegian Tax Administration has not published your income and tax figures for that year, please state the annual income shown on your pay slip for December for that year.',
     'inntektenDin.loennsinntekt.inntektEtterDoedsfall': 'What was your income after the death?',
     'inntektenDin.loennsinntekt.inntektEtterDoedsfall.beskrivelse':
         'From the month after the death and up to and including december that year. If the death was in December, Hvis dødsfallmåneden var desember, state 0 kroner.',
@@ -302,7 +302,8 @@ export default {
         'What do you expect to earn in gross annual income for next year?',
     'inntektenDin.loennsinntekt.arbeidsinntektIAar.aarsinntekt':
         'What do you expect to earn in gross annual income this year?',
-    'inntektenDin.loennsinntekt.arbeidsinntektIAar.aarsinntekt.beskrivelse': 'Please state from January to end of December.',
+    'inntektenDin.loennsinntekt.arbeidsinntektIAar.aarsinntekt.beskrivelse':
+        'Please state from January to end of December.',
     'inntektenDin.loennsinntekt.forventerEndringAvInntekt.svar':
         'Do you expect your income to change in the near future?',
     'inntektenDin.loennsinntekt.forventerEndringAvInntekt.grunn': 'What is the reason for the change?',
@@ -341,7 +342,10 @@ export default {
     'inntektenDin.naeringsinntekt.arbeidsinntektIAar.aarsinntekt':
         'What do you expect to earn in gross annual business income this year?',
     'inntektenDin.naeringsinntekt.sesongbasertNaeringsinntekt.svar': 'Is this seasonal work?',
-    'inntektenDin.naeringsinntekt.sesongbasertNaeringsinntekt.beskrivelse': 'Please provide a short description of the work',
+    'inntektenDin.naeringsinntekt.sesongbasertNaeringsinntekt.svar.beskrivelse':
+        'We need to know if your business income was earned evenly throughout the year.',
+    'inntektenDin.naeringsinntekt.sesongbasertNaeringsinntekt.beskrivelse':
+        'Please provide a short description of the work',
     'inntektenDin.naeringsinntekt.forventerEndringAvInntekt.svar':
         'Do you expect your income to change in the near future?',
     'inntektenDin.naeringsinntekt.forventerEndringAvInntekt.grunn': 'What is the reason for the change?',

--- a/apps/omstillingsstoenad-ui/src/locales/en.ts
+++ b/apps/omstillingsstoenad-ui/src/locales/en.ts
@@ -932,6 +932,10 @@ export default {
         'State gross income from work for year before death. Gross income is income before tax',
     'feil.loennsinntekt.utland.arbeidsinntektAaretFoer.required':
         'State gross income from work for year before death. Gross income is income before tax',
+    'feil.loennsinntekt.utland.arbeidsinntektDoedsfallsaaret.required':
+        'State gross income from work in the year of the death. Gross income is income before tax',
+    'feil.loennsinntekt.norge.arbeidsinntektDoedsfallsaaret.required':
+        'State gross income from work in the year of the death. Gross income is income before tax',
     'feil.loennsinntekt.norge.arbeidsinntektIAar.tilDoedsfall.required':
         'State gross income from work prior to the death. Gross income is income before tax',
     'feil.loennsinntekt.utland.arbeidsinntektIAar.tilDoedsfall.required':
@@ -948,6 +952,10 @@ export default {
         'State gross business income for the year before the death. Gross income is income before tax',
     'feil.naeringsinntekt.utland.arbeidsinntektAaretFoer.required':
         'State gross business income for the year before the death. Gross income is income before tax',
+    'feil.naeringsinntekt.utland.arbeidsinntektDoedsfallsaaret.required':
+        'State gross annual income in the year of the death. Gross income is income before tax',
+    'feil.naeringsinntekt.norge.arbeidsinntektDoedsfallsaaret.required':
+        'State gross annual income in the year of the death. Gross income is income before tax',
     'feil.naeringsinntekt.norge.arbeidsinntektIAar.tilDoedsfall.required':
         'State gross business income prior to the death. Gross income is income before tax',
     'feil.naeringsinntekt.utland.arbeidsinntektIAar.tilDoedsfall.required':

--- a/apps/omstillingsstoenad-ui/src/locales/en.ts
+++ b/apps/omstillingsstoenad-ui/src/locales/en.ts
@@ -914,6 +914,12 @@ export default {
     'feil.utbetalingsInformasjon.swift.validate': 'Invalid SWIFT code or BIC',
     'feil.inntektstyper.required': 'State your type of income',
     'feil.loennsinntekt.norgeEllerUtland.required': 'Tick the source of your income',
+    'feil.loennsinntekt.norge.inntektEtterDoedsfall.required': 'State your income from employment after the death',
+    'feil.loennsinntekt.norge.arbeidsinntektIAar.aarsinntekt.required':
+        'State expected income from employment this year',
+    'feil.loennsinntekt.utland.inntektEtterDoedsfall.required': 'State your income from employment after the death',
+    'feil.loennsinntekt.utland.arbeidsinntektIAar.aarsinntekt.required':
+        'State expected income from employment this year',
     'feil.loennsinntekt.norge.arbeidsinntektAaretFoer.required':
         'State gross income from work for year before death. Gross income is income before tax',
     'feil.loennsinntekt.utland.arbeidsinntektAaretFoer.required':
@@ -945,6 +951,16 @@ export default {
     'feil.naeringsinntekt.forventerEndringAvInntekt.svar.required': 'Expectations about income must be answered',
     'feil.naeringsinntekt.forventerEndringAvInntekt.grunn.required': 'State the reason for the change',
     'feil.naeringsinntekt.forventerEndringAvInntekt.annenGrunn.required': 'Describe the changes must be answered',
+    'feil.naeringsinntekt.norge.sesongbasertNaeringsinntekt.svar.required':
+        'You must choose whether the this is seasonal work or not',
+    'feil.naeringsinntekt.utland.sesongbasertNaeringsinntekt.svar.required':
+        'You must choose whether the this is seasonal work or not',
+    'feil.naeringsinntekt.norge.sesongbasertNaeringsinntekt.beskrivelse.required':
+        'Please provide a short description of the work',
+    'feil.naeringsinntekt.utland.sesongbasertNaeringsinntekt.beskrivelse.required':
+        'Please provide a short description of the work',
+    'feil.naeringsinntekt.norge.arbeidsinntektIAar.aarsinntekt.required': 'State expected business income this year',
+    'feil.naeringsinntekt.utland.arbeidsinntektIAar.aarsinntekt.required': 'State expected business income this year',
     'feil.pensjonEllerUfoere.pensjonstype.required': 'State which type of pension or benefits you receive',
     'feil.pensjonEllerUfoere.tjenestepensjonsordning.type.required': 'Choose which pension you receive',
     'feil.pensjonEllerUfoere.tjenestepensjonsordning.utbetaler.required':

--- a/apps/omstillingsstoenad-ui/src/locales/en.ts
+++ b/apps/omstillingsstoenad-ui/src/locales/en.ts
@@ -277,6 +277,13 @@ export default {
     'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.tittel': 'Your income from work before the death',
     'inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer':
         'What was your gross annual income in the year before the death?',
+    'inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer.doedsfallAaretFoer':
+        'What was your gross annual income in the year of the death?',
+    'inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse':
+        'From january and up to and including december',
+    'inntektenDin.loennsinntekt.norge.inntektEtterDoedsfall': 'What was your income after the death?',
+    'inntektenDin.loennsinntekt.norge.inntektEtterDoedsfall.beskrivelse':
+        'From the month after the death and up to and including december that year. If the death was in December, Hvis dødsfallmåneden var desember, state 0 kroner.',
     'inntektenDin.loennsinntekt.utland.arbeidsinntektAaretFoer':
         'What was your gross annual income in the year before the death?',
     'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.beskrivelse':
@@ -293,6 +300,8 @@ export default {
         'What do you expect to earn in gross annual income for next year?',
     'inntektenDin.loennsinntekt.utland.arbeidsinntektIAar.etterDoedsfall':
         'What do you expect to earn in gross annual income for next year?',
+    'inntektenDin.loennsinntekt.norge.arbeidsinntektIAar.aarsinntekt':
+        'What do you expect to earn in gross annual income this year?',
     'inntektenDin.loennsinntekt.forventerEndringAvInntekt.svar':
         'Do you expect your income to change in the near future?',
     'inntektenDin.loennsinntekt.forventerEndringAvInntekt.grunn': 'What is the reason for the change?',
@@ -309,6 +318,9 @@ export default {
         'What was your gross annual income in the year before the death?',
     'inntektenDin.naeringsinntekt.utland.arbeidsinntektAaretFoer':
         'What was your gross annual income in the year before the death?',
+    'inntektenDin.naeringsinntekt.norge.arbeidsinntektAaretFoer.doedsfallAaretFoer':
+        'What was your gross annual business income in the year of the death?',
+    'inntektenDin.naeringsinntekt.norge.inntektEtterDoedsfall': 'What was your income after the death?',
     'inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.beskrivelse':
         'If the Norwegian Tax Administration has not published your income for that year, please estimate your business income.',
     'inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.beskrivelse.utland':
@@ -325,6 +337,8 @@ export default {
         'What do you expect to earn in gross annual income for next year?',
     'inntektenDin.naeringsinntekt.arbeidsinntektIAar.etterDoedsfall.beskrivelse':
         'State your expected business income, from the month of the death until December.',
+    'inntektenDin.naeringsinntekt.norge.arbeidsinntektIAar.aarsinntekt':
+        'What do you expect to earn in gross annual business income this year?',
     'inntektenDin.naeringsinntekt.forventerEndringAvInntekt.svar':
         'Do you expect your income to change in the near future?',
     'inntektenDin.naeringsinntekt.forventerEndringAvInntekt.grunn': 'What is the reason for the change?',
@@ -421,9 +435,10 @@ export default {
     'omDenAvdoede.statsborgerskap': 'Nationality',
     'omDenAvdoede.statsborgerskapPlaceholder': 'For example: Norwegian',
     'omDenAvdoede.datoForDoedsfallet': 'When did the death occur?',
-    "omDenAvdoede.datoForDoedsfallet.foerDesember": "Because the deceased's time of death was before December 2023 you must apply for a ",
-    "omDenAvdoede.datoForDoedsfallet.foerDesember.link": "survivor's pension.",
-    "omDenAvdoede.datoForDoedsfallet.foerDesember.href": "https://www.nav.no/gjenlevendepensjon/en",
+    'omDenAvdoede.datoForDoedsfallet.foerDesember':
+        "Because the deceased's time of death was before December 2023 you must apply for a ",
+    'omDenAvdoede.datoForDoedsfallet.foerDesember.link': "survivor's pension.",
+    'omDenAvdoede.datoForDoedsfallet.foerDesember.href': 'https://www.nav.no/gjenlevendepensjon/en',
     'omDenAvdoede.boddEllerJobbetUtland.tittel': 'Time spent outside Norway',
     'omDenAvdoede.boddEllerJobbetUtland.ingress':
         'We need to know if the deceased has lived or worked outside Norway. This may both affect the size of the survivor’s pension you receive and give you pension rights from other countries.',
@@ -545,7 +560,8 @@ export default {
     'soeknadKvittering.seSaken.informasjon.lenkeMittNAV.tekst': 'your personal NAV page',
     'soeknadKvittering.seSaken.informasjon.innhold2':
         'Curious about how long this will take? That information is available here: ',
-    'soeknadKvittering.seSaken.informasjon.lenkeSaksbehandlingstid.href': 'https://www.nav.no/saksbehandlingstider/en#omstillingsstonad',
+    'soeknadKvittering.seSaken.informasjon.lenkeSaksbehandlingstid.href':
+        'https://www.nav.no/saksbehandlingstider/en#omstillingsstonad',
     'soeknadKvittering.seSaken.informasjon.lenkeSaksbehandlingstid.tekst': 'Expected case processing time.',
     'soeknadKvittering.andreStoenader.tittel': 'You may also be entitled to other benefits',
     'soeknadKvittering.andreStoenader.informasjon':
@@ -555,8 +571,7 @@ export default {
     'soeknadKvittering.andreStoenader.stoenadListe.barnetilsyn.tekst': 'Child care benefit for a surviving spouse',
     'soeknadKvittering.andreStoenader.stoenadListe.barnetrygd.tekst': 'Extended child benefit',
     'soeknadKvittering.andreStoenader.stoenadListe.tillegg.tekst': 'other benefits for a surviving spouse.',
-    'soeknadKvittering.andreStoenader.stoenadListe.tillegg.href':
-        'https://www.nav.no/omstillingsstonad#andre-stonader',
+    'soeknadKvittering.andreStoenader.stoenadListe.tillegg.href': 'https://www.nav.no/omstillingsstonad#andre-stonader',
     'soeknadKvittering.andreStoenader.andreInformasjon':
         'You will find more information about supplemental benefits on ',
     'soeknadKvittering.spoersmaal.knapp': 'Read more about transitional benefits here',

--- a/apps/omstillingsstoenad-ui/src/locales/en.ts
+++ b/apps/omstillingsstoenad-ui/src/locales/en.ts
@@ -302,6 +302,7 @@ export default {
         'What do you expect to earn in gross annual income for next year?',
     'inntektenDin.loennsinntekt.arbeidsinntektIAar.aarsinntekt':
         'What do you expect to earn in gross annual income this year?',
+    'inntektenDin.loennsinntekt.arbeidsinntektIAar.aarsinntekt.beskrivelse': 'Oppgi fra januar til og med desember.',
     'inntektenDin.loennsinntekt.forventerEndringAvInntekt.svar':
         'Do you expect your income to change in the near future?',
     'inntektenDin.loennsinntekt.forventerEndringAvInntekt.grunn': 'What is the reason for the change?',
@@ -318,7 +319,7 @@ export default {
         'What was your gross annual income in the year before the death?',
     'inntektenDin.naeringsinntekt.utland.arbeidsinntektAaretFoer':
         'What was your gross annual income in the year before the death?',
-    'inntektenDin.naeringsinntekt.norge.arbeidsinntektAaretFoer.doedsfallAaretFoer':
+    'inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer':
         'What was your gross annual business income in the year of the death?',
     'inntektenDin.naeringsinntekt.norge.inntektEtterDoedsfall': 'What was your income after the death?',
     'inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.beskrivelse':
@@ -337,8 +338,10 @@ export default {
         'What do you expect to earn in gross annual income for next year?',
     'inntektenDin.naeringsinntekt.arbeidsinntektIAar.etterDoedsfall.beskrivelse':
         'State your expected business income, from the month of the death until December.',
-    'inntektenDin.naeringsinntekt.norge.arbeidsinntektIAar.aarsinntekt':
+    'inntektenDin.naeringsinntekt.arbeidsinntektIAar.aarsinntekt':
         'What do you expect to earn in gross annual business income this year?',
+    'inntektenDin.naeringsinntekt.sesongbasertNaeringsinntekt.svar': 'Er arbeidet sesongbasert?',
+    'inntektenDin.naeringsinntekt.sesongbasertNaeringsinntekt.beskrivelse': 'Gi en kort beskrivelse av arbeidet',
     'inntektenDin.naeringsinntekt.forventerEndringAvInntekt.svar':
         'Do you expect your income to change in the near future?',
     'inntektenDin.naeringsinntekt.forventerEndringAvInntekt.grunn': 'What is the reason for the change?',

--- a/apps/omstillingsstoenad-ui/src/locales/en.ts
+++ b/apps/omstillingsstoenad-ui/src/locales/en.ts
@@ -322,6 +322,8 @@ export default {
         'What was your gross annual income in the year before the death?',
     'inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer':
         'What was your gross annual business income in the year of the death?',
+    'inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse':
+        ' If the Norwegian Tax Administration has not published your income for that year, please estimate your business income for that year.',
     'inntektenDin.naeringsinntekt.norge.inntektEtterDoedsfall': 'What was your income after the death?',
     'inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.beskrivelse':
         'If the Norwegian Tax Administration has not published your income for that year, please estimate your business income for that year.',

--- a/apps/omstillingsstoenad-ui/src/locales/en.ts
+++ b/apps/omstillingsstoenad-ui/src/locales/en.ts
@@ -280,7 +280,7 @@ export default {
     'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer':
         'What was your gross annual income in the year of the death?',
     'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse':
-        'From january and up to and including december',
+        'Please state from January to end of December.',
     'inntektenDin.loennsinntekt.inntektEtterDoedsfall': 'What was your income after the death?',
     'inntektenDin.loennsinntekt.inntektEtterDoedsfall.beskrivelse':
         'From the month after the death and up to and including december that year. If the death was in December, Hvis dødsfallmåneden var desember, state 0 kroner.',
@@ -302,7 +302,7 @@ export default {
         'What do you expect to earn in gross annual income for next year?',
     'inntektenDin.loennsinntekt.arbeidsinntektIAar.aarsinntekt':
         'What do you expect to earn in gross annual income this year?',
-    'inntektenDin.loennsinntekt.arbeidsinntektIAar.aarsinntekt.beskrivelse': 'Oppgi fra januar til og med desember.',
+    'inntektenDin.loennsinntekt.arbeidsinntektIAar.aarsinntekt.beskrivelse': 'Please state from January to end of December.',
     'inntektenDin.loennsinntekt.forventerEndringAvInntekt.svar':
         'Do you expect your income to change in the near future?',
     'inntektenDin.loennsinntekt.forventerEndringAvInntekt.grunn': 'What is the reason for the change?',
@@ -323,7 +323,7 @@ export default {
         'What was your gross annual business income in the year of the death?',
     'inntektenDin.naeringsinntekt.norge.inntektEtterDoedsfall': 'What was your income after the death?',
     'inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.beskrivelse':
-        'If the Norwegian Tax Administration has not published your income for that year, please estimate your business income.',
+        'If the Norwegian Tax Administration has not published your income for that year, please estimate your business income for that year.',
     'inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.beskrivelse.utland':
         'If you do not know your income for that year, please estimate your business income.',
     'inntektenDin.naeringsinntekt.norge.arbeidsinntektIAar.tilDoedsfall':
@@ -340,8 +340,8 @@ export default {
         'State your expected business income, from the month of the death until December.',
     'inntektenDin.naeringsinntekt.arbeidsinntektIAar.aarsinntekt':
         'What do you expect to earn in gross annual business income this year?',
-    'inntektenDin.naeringsinntekt.sesongbasertNaeringsinntekt.svar': 'Er arbeidet sesongbasert?',
-    'inntektenDin.naeringsinntekt.sesongbasertNaeringsinntekt.beskrivelse': 'Gi en kort beskrivelse av arbeidet',
+    'inntektenDin.naeringsinntekt.sesongbasertNaeringsinntekt.svar': 'Is this seasonal work?',
+    'inntektenDin.naeringsinntekt.sesongbasertNaeringsinntekt.beskrivelse': 'Please provide a short description of the work',
     'inntektenDin.naeringsinntekt.forventerEndringAvInntekt.svar':
         'Do you expect your income to change in the near future?',
     'inntektenDin.naeringsinntekt.forventerEndringAvInntekt.grunn': 'What is the reason for the change?',

--- a/apps/omstillingsstoenad-ui/src/locales/nb.ts
+++ b/apps/omstillingsstoenad-ui/src/locales/nb.ts
@@ -273,13 +273,13 @@ export default {
     'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer':
         'Hva var brutto årsinntekt i dødsfallsåret?',
     'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse':
-        'Dersom fastsettelsen av inntekten fra Skatteeetaten ikke er tilgjengelig ennå, må du anslå næringsinntekten det året.',
+        'Dersom fastsettelsen av inntekten fra Skatteetaten ikke er tilgjengelig ennå, kan du oppgi årsinntekten som vises på lønnsslippen for desember for det året.',
     'inntektenDin.loennsinntekt.inntektEtterDoedsfall': 'Hva hadde du i arbeidsinntekt etter dødsfallet?',
     'inntektenDin.loennsinntekt.inntektEtterDoedsfall.beskrivelse':
-        'Fra måneden etter dødsfallet til og med desember det året. Hvis dødsfallmåneden var desember, oppgir du 0 kroner.',
+        'Oppgi fra måneden etter dødsfallet til og med desember det året. Hvis dødsfallsmåneden var desember, oppgir du 0 kroner.',
     'inntektenDin.loennsinntekt.utland.arbeidsinntektAaretFoer': 'Hva var brutto årsinntekt året før dødsfallet?',
     'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.beskrivelse':
-        'Dersom fastsettelsen av inntekten fra Skatteetaten ikke er tilgjengelig ennå, kan du oppgi totalinntekten som vises på lønnsslippen for desember.',
+        'Dersom fastsettelsen av inntekten fra Skatteetaten ikke er tilgjengelig ennå, kan du oppgi årsinntekten som vises på lønnsslippen for desember.',
     'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.beskrivelse.utland':
         'Dersom du ikke kjenner inntekten dette året, kan du oppgi årsinntekten som vises på lønnsslippen for desember.',
     'inntektenDin.loennsinntekt.norge.arbeidsinntektIAar.tilDoedsfall':
@@ -310,6 +310,8 @@ export default {
     'inntektenDin.naeringsinntekt.utland.arbeidsinntektAaretFoer': 'Hva var brutto årsinntekt året før dødsfallet?',
     'inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer':
         'Hva var brutto årsinntekt i dødsfallsåret?',
+    'inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse':
+        'Dersom fastsettelsen av inntekten fra Skatteetaten ikke er tilgjengelig ennå, må du anslå næringsinntekten det året.',
     'inntektenDin.naeringsinntekt.norge.inntektEtterDoedsfall': 'Hva hadde du i næringsinntekt etter dødsfallet?',
     'inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.beskrivelse':
         'Dersom fastsettelsen av inntekten fra Skatteetaten ikke er tilgjengelig ennå, må du anslå næringsinntekten.',
@@ -328,6 +330,8 @@ export default {
     'inntektenDin.naeringsinntekt.arbeidsinntektIAar.aarsinntekt':
         'Hva forventer du å ha i brutto næringsinntekt i år?',
     'inntektenDin.naeringsinntekt.sesongbasertNaeringsinntekt.svar': 'Er arbeidet sesongbasert?',
+    'inntektenDin.naeringsinntekt.sesongbasertNaeringsinntekt.svar.beskrivelse':
+        'Vi trenger å vite om næringsinntekten er jevnt opptjent gjennom året.',
     'inntektenDin.naeringsinntekt.sesongbasertNaeringsinntekt.beskrivelse': 'Gi en kort beskrivelse av arbeidet',
     'inntektenDin.naeringsinntekt.forventerEndringAvInntekt.svar':
         'Regner du med at inntekten din endrer seg fremover i tid?',

--- a/apps/omstillingsstoenad-ui/src/locales/nb.ts
+++ b/apps/omstillingsstoenad-ui/src/locales/nb.ts
@@ -274,6 +274,8 @@ export default {
         'Hva var brutto årsinntekt i dødsfallsåret?',
     'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse':
         'Dersom fastsettelsen av inntekten fra Skatteetaten ikke er tilgjengelig ennå, kan du oppgi årsinntekten som vises på lønnsslippen for desember for det året.',
+    'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse.utland':
+        'Dersom du ikke kjenner inntekten dette året, kan du oppgi årsinntekten som vises på lønnsslippen for desember.',
     'inntektenDin.loennsinntekt.inntektEtterDoedsfall': 'Hva hadde du i arbeidsinntekt etter dødsfallet?',
     'inntektenDin.loennsinntekt.inntektEtterDoedsfall.beskrivelse':
         'Oppgi fra måneden etter dødsfallet til og med desember det året. Hvis dødsfallsmåneden var desember, oppgir du 0 kroner.',

--- a/apps/omstillingsstoenad-ui/src/locales/nb.ts
+++ b/apps/omstillingsstoenad-ui/src/locales/nb.ts
@@ -270,12 +270,12 @@ export default {
         'Hvis inntekten din endrer seg etter du har sendt inn søknaden, må du melde fra om endringen til oss.',
     'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.tittel': 'Arbeidsinntekten din året før dødsfallet',
     'inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer': 'Hva var brutto årsinntekt året før dødsfallet?',
-    'inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer.doedsfallAaretFoer':
+    'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer':
         'Hva var brutto årsinntekt i dødsfallsåret?',
-    'inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse':
+    'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse':
         'Fra januar til og med desember',
-    'inntektenDin.loennsinntekt.norge.inntektEtterDoedsfall': 'Hva hadde du i arbeidsinntekt etter dødsfallet?',
-    'inntektenDin.loennsinntekt.norge.inntektEtterDoedsfall.beskrivelse':
+    'inntektenDin.loennsinntekt.inntektEtterDoedsfall': 'Hva hadde du i arbeidsinntekt etter dødsfallet?',
+    'inntektenDin.loennsinntekt.inntektEtterDoedsfall.beskrivelse':
         'Fra måneden etter dødsfallet til og med desember det året. Hvis dødsfallmåneden var desember, oppgir du 0 kroner.',
     'inntektenDin.loennsinntekt.utland.arbeidsinntektAaretFoer': 'Hva var brutto årsinntekt året før dødsfallet?',
     'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.beskrivelse':
@@ -292,7 +292,7 @@ export default {
         'Hva forventer du i brutto årsinntekt til neste år?',
     'inntektenDin.loennsinntekt.utland.arbeidsinntektIAar.etterDoedsfall':
         'Hva forventer du i brutto årsinntekt til neste år?',
-    'inntektenDin.loennsinntekt.norge.arbeidsinntektIAar.aarsinntekt':
+    'inntektenDin.loennsinntekt.arbeidsinntektIAar.aarsinntekt':
         'Hva forventer du å ha i brutto arbeidsinntekt i år?',
     'inntektenDin.loennsinntekt.forventerEndringAvInntekt.svar':
         'Regner du med at inntekten din endrer seg fremover i tid?',

--- a/apps/omstillingsstoenad-ui/src/locales/nb.ts
+++ b/apps/omstillingsstoenad-ui/src/locales/nb.ts
@@ -879,12 +879,16 @@ export default {
     'feil.utbetalingsInformasjon.swift.validate': 'Ugyldig SWIFT/BIC kode',
     'feil.inntektstyper.required': 'Oppgi hvilken inntektstype du har',
     'feil.loennsinntekt.norgeEllerUtland.required': 'Du må krysse av hvor du får arbeidsinntekt fra',
+    'feil.loennsinntekt.norge.inntektEtterDoedsfall.required':'Oppgi arbeidsinntekten din etter dødsfallet',
+    'feil.loennsinntekt.norge.arbeidsinntektIAar.aarsinntekt.required':'Oppgi forventet arbeidsinntekt i år',
     'feil.loennsinntekt.norge.arbeidsinntektAaretFoer.required':
         'Oppgi brutto arbeidsinntekt året før dødsfallet. Brutto inntekt er inntekten før skatt',
     'feil.loennsinntekt.norge.arbeidsinntektIAar.tilDoedsfall.required':
         'Oppgi brutto arbeidsinntekt frem til dødsfallet. Brutto inntekt er inntekten før skatt',
     'feil.loennsinntekt.norge.arbeidsinntektIAar.etterDoedsfall.required':
         'Oppgi brutto arbeidsinntekt etter dødsfallet. Brutto inntekt er inntekten før skatt',
+    'feil.loennsinntekt.utland.inntektEtterDoedsfall.required':'Oppgi arbeidsinntekten din etter dødsfallet',
+    'feil.loennsinntekt.utland.arbeidsinntektIAar.aarsinntekt.required':'Oppgi forventet arbeidsinntekt i år',
     'feil.loennsinntekt.utland.arbeidsinntektAaretFoer.required':
         'Oppgi brutto arbeidsinntekt året før dødsfallet. Brutto inntekt er inntekten før skatt',
     'feil.loennsinntekt.utland.arbeidsinntektIAar.tilDoedsfall.required':
@@ -910,6 +914,13 @@ export default {
     'feil.naeringsinntekt.forventerEndringAvInntekt.svar.required': 'Forventning rundt inntekt må besvares',
     'feil.naeringsinntekt.forventerEndringAvInntekt.grunn.required': 'Oppgi grunnen til endringene',
     'feil.naeringsinntekt.forventerEndringAvInntekt.annenGrunn.required': 'Beskrivelse av endringene må besvares',
+    'feil.naeringsinntekt.norge.sesongbasertNaeringsinntekt.svar.required':'Du må velge om arbeidet et sesongbasert eller ikke',
+    'feil.naeringsinntekt.norge.sesongbasertNaeringsinntekt.beskrivelse.required':'Gi en kort beskrivelse av arbeidet',
+    'feil.naeringsinntekt.norge.arbeidsinntektIAar.aarsinntekt.required':'Oppgi forventet næringsinntekt i år',
+    'feil.naeringsinntekt.utland.sesongbasertNaeringsinntekt.svar.required':'Du må velge om arbeidet et sesongbasert eller ikke',
+    'feil.naeringsinntekt.utland.sesongbasertNaeringsinntekt.beskrivelse.required':'Gi en kort beskrivelse av arbeidet',
+    'feil.naeringsinntekt.utland.arbeidsinntektIAar.aarsinntekt.required':'Oppgi forventet næringsinntekt i år',
+
     'feil.pensjonEllerUfoere.pensjonstype.required': 'Oppgi hvilken pensjon eller trygd du har',
     'feil.pensjonEllerUfoere.tjenestepensjonsordning.type.required': 'Velg hvilken pensjon du mottar',
     'feil.pensjonEllerUfoere.tjenestepensjonsordning.utbetaler.required':

--- a/apps/omstillingsstoenad-ui/src/locales/nb.ts
+++ b/apps/omstillingsstoenad-ui/src/locales/nb.ts
@@ -889,6 +889,10 @@ export default {
     'feil.loennsinntekt.norge.arbeidsinntektIAar.aarsinntekt.required': 'Oppgi forventet arbeidsinntekt i år',
     'feil.loennsinntekt.norge.arbeidsinntektAaretFoer.required':
         'Oppgi brutto arbeidsinntekt året før dødsfallet. Brutto inntekt er inntekten før skatt',
+    'feil.loennsinntekt.utland.arbeidsinntektDoedsfallsaaret.required':
+        'Oppgi brutto arbeidsinntekt i dødsfallsåret. Brutto inntekt er inntekten før skatt',
+    'feil.loennsinntekt.norge.arbeidsinntektDoedsfallsaaret.required':
+        'Oppgi brutto arbeidsinntekt i dødsfallsåret. Brutto inntekt er inntekten før skatt',
     'feil.loennsinntekt.norge.arbeidsinntektIAar.tilDoedsfall.required':
         'Oppgi brutto arbeidsinntekt frem til dødsfallet. Brutto inntekt er inntekten før skatt',
     'feil.loennsinntekt.norge.arbeidsinntektIAar.etterDoedsfall.required':
@@ -907,6 +911,10 @@ export default {
     'feil.naeringsinntekt.norgeEllerUtland.required': 'Du må krysse av hvor du får næringsinntekt fra',
     'feil.naeringsinntekt.norge.arbeidsinntektAaretFoer.required':
         'Oppgi brutto næringsinntekt året før dødsfallet. Brutto inntekt er inntekten før skatt',
+    'feil.naeringsinntekt.utland.arbeidsinntektDoedsfallsaaret.required':
+        'Oppgi brutto årsinntekt i dødsfallsåret. Brutto inntekt er inntekten før skatt',
+    'feil.naeringsinntekt.norge.arbeidsinntektDoedsfallsaaret.required':
+        'Oppgi brutto årsinntekt i dødsfallsåret. Brutto inntekt er inntekten før skatt',
     'feil.naeringsinntekt.norge.arbeidsinntektIAar.tilDoedsfall.required':
         'Oppgi brutto næringsinntekt frem til dødsfallet. Brutto inntekt er inntekten før skatt',
     'feil.naeringsinntekt.norge.arbeidsinntektIAar.etterDoedsfall.required':

--- a/apps/omstillingsstoenad-ui/src/locales/nb.ts
+++ b/apps/omstillingsstoenad-ui/src/locales/nb.ts
@@ -879,16 +879,16 @@ export default {
     'feil.utbetalingsInformasjon.swift.validate': 'Ugyldig SWIFT/BIC kode',
     'feil.inntektstyper.required': 'Oppgi hvilken inntektstype du har',
     'feil.loennsinntekt.norgeEllerUtland.required': 'Du må krysse av hvor du får arbeidsinntekt fra',
-    'feil.loennsinntekt.norge.inntektEtterDoedsfall.required':'Oppgi arbeidsinntekten din etter dødsfallet',
-    'feil.loennsinntekt.norge.arbeidsinntektIAar.aarsinntekt.required':'Oppgi forventet arbeidsinntekt i år',
+    'feil.loennsinntekt.norge.inntektEtterDoedsfall.required': 'Oppgi arbeidsinntekten din etter dødsfallet',
+    'feil.loennsinntekt.norge.arbeidsinntektIAar.aarsinntekt.required': 'Oppgi forventet arbeidsinntekt i år',
     'feil.loennsinntekt.norge.arbeidsinntektAaretFoer.required':
         'Oppgi brutto arbeidsinntekt året før dødsfallet. Brutto inntekt er inntekten før skatt',
     'feil.loennsinntekt.norge.arbeidsinntektIAar.tilDoedsfall.required':
         'Oppgi brutto arbeidsinntekt frem til dødsfallet. Brutto inntekt er inntekten før skatt',
     'feil.loennsinntekt.norge.arbeidsinntektIAar.etterDoedsfall.required':
         'Oppgi forventet næringsinntekt til neste år. Brutto inntekt er inntekten før skatt\n',
-    'feil.loennsinntekt.utland.inntektEtterDoedsfall.required':'Oppgi arbeidsinntekten din etter dødsfallet',
-    'feil.loennsinntekt.utland.arbeidsinntektIAar.aarsinntekt.required':'Oppgi forventet arbeidsinntekt i år',
+    'feil.loennsinntekt.utland.inntektEtterDoedsfall.required': 'Oppgi arbeidsinntekten din etter dødsfallet',
+    'feil.loennsinntekt.utland.arbeidsinntektIAar.aarsinntekt.required': 'Oppgi forventet arbeidsinntekt i år',
     'feil.loennsinntekt.utland.arbeidsinntektAaretFoer.required':
         'Oppgi brutto arbeidsinntekt året før dødsfallet. Brutto inntekt er inntekten før skatt',
     'feil.loennsinntekt.utland.arbeidsinntektIAar.tilDoedsfall.required':
@@ -914,13 +914,15 @@ export default {
     'feil.naeringsinntekt.forventerEndringAvInntekt.svar.required': 'Forventning rundt inntekt må besvares',
     'feil.naeringsinntekt.forventerEndringAvInntekt.grunn.required': 'Oppgi grunnen til endringene',
     'feil.naeringsinntekt.forventerEndringAvInntekt.annenGrunn.required': 'Beskrivelse av endringene må besvares',
-    'feil.naeringsinntekt.norge.sesongbasertNaeringsinntekt.svar.required':'Du må velge om arbeidet et sesongbasert eller ikke',
-    'feil.naeringsinntekt.norge.sesongbasertNaeringsinntekt.beskrivelse.required':'Gi en kort beskrivelse av arbeidet',
-    'feil.naeringsinntekt.norge.arbeidsinntektIAar.aarsinntekt.required':'Oppgi forventet næringsinntekt i år',
-    'feil.naeringsinntekt.utland.sesongbasertNaeringsinntekt.svar.required':'Du må velge om arbeidet et sesongbasert eller ikke',
-    'feil.naeringsinntekt.utland.sesongbasertNaeringsinntekt.beskrivelse.required':'Gi en kort beskrivelse av arbeidet',
-    'feil.naeringsinntekt.utland.arbeidsinntektIAar.aarsinntekt.required':'Oppgi forventet næringsinntekt i år',
-
+    'feil.naeringsinntekt.norge.sesongbasertNaeringsinntekt.svar.required':
+        'Du må velge om arbeidet er sesongbasert eller ikke',
+    'feil.naeringsinntekt.norge.sesongbasertNaeringsinntekt.beskrivelse.required': 'Gi en kort beskrivelse av arbeidet',
+    'feil.naeringsinntekt.norge.arbeidsinntektIAar.aarsinntekt.required': 'Oppgi forventet næringsinntekt i år',
+    'feil.naeringsinntekt.utland.sesongbasertNaeringsinntekt.svar.required':
+        'Du må velge om arbeidet et sesongbasert eller ikke',
+    'feil.naeringsinntekt.utland.sesongbasertNaeringsinntekt.beskrivelse.required':
+        'Gi en kort beskrivelse av arbeidet',
+    'feil.naeringsinntekt.utland.arbeidsinntektIAar.aarsinntekt.required': 'Oppgi forventet næringsinntekt i år',
     'feil.pensjonEllerUfoere.pensjonstype.required': 'Oppgi hvilken pensjon eller trygd du har',
     'feil.pensjonEllerUfoere.tjenestepensjonsordning.type.required': 'Velg hvilken pensjon du mottar',
     'feil.pensjonEllerUfoere.tjenestepensjonsordning.utbetaler.required':

--- a/apps/omstillingsstoenad-ui/src/locales/nb.ts
+++ b/apps/omstillingsstoenad-ui/src/locales/nb.ts
@@ -273,7 +273,7 @@ export default {
     'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer':
         'Hva var brutto årsinntekt i dødsfallsåret?',
     'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse':
-        'Fra januar til og med desember',
+        'Dersom fastsettelsen av inntekten fra Skatteeetaten ikke er tilgjengelig ennå, må du anslå næringsinntekten det året.',
     'inntektenDin.loennsinntekt.inntektEtterDoedsfall': 'Hva hadde du i arbeidsinntekt etter dødsfallet?',
     'inntektenDin.loennsinntekt.inntektEtterDoedsfall.beskrivelse':
         'Fra måneden etter dødsfallet til og med desember det året. Hvis dødsfallmåneden var desember, oppgir du 0 kroner.',
@@ -292,8 +292,8 @@ export default {
         'Hva forventer du i brutto årsinntekt til neste år?',
     'inntektenDin.loennsinntekt.utland.arbeidsinntektIAar.etterDoedsfall':
         'Hva forventer du i brutto årsinntekt til neste år?',
-    'inntektenDin.loennsinntekt.arbeidsinntektIAar.aarsinntekt':
-        'Hva forventer du å ha i brutto arbeidsinntekt i år?',
+    'inntektenDin.loennsinntekt.arbeidsinntektIAar.aarsinntekt': 'Hva forventer du å ha i brutto arbeidsinntekt i år?',
+    'inntektenDin.loennsinntekt.arbeidsinntektIAar.aarsinntekt.beskrivelse': 'Oppgi fra januar til og med desember.',
     'inntektenDin.loennsinntekt.forventerEndringAvInntekt.svar':
         'Regner du med at inntekten din endrer seg fremover i tid?',
     'inntektenDin.loennsinntekt.forventerEndringAvInntekt.grunn': 'Hva er grunnen til endringene?',
@@ -308,7 +308,7 @@ export default {
         'Hvis inntekten din endrer seg etter du har sendt inn søknaden, må du melde fra om endringen til oss.',
     'inntektenDin.naeringsinntekt.norge.arbeidsinntektAaretFoer': 'Hva var brutto årsinntekt året før dødsfallet?',
     'inntektenDin.naeringsinntekt.utland.arbeidsinntektAaretFoer': 'Hva var brutto årsinntekt året før dødsfallet?',
-    'inntektenDin.naeringsinntekt.norge.arbeidsinntektAaretFoer.doedsfallAaretFoer':
+    'inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer':
         'Hva var brutto årsinntekt i dødsfallsåret?',
     'inntektenDin.naeringsinntekt.norge.inntektEtterDoedsfall': 'Hva hadde du i næringsinntekt etter dødsfallet?',
     'inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.beskrivelse':
@@ -325,8 +325,10 @@ export default {
         'Hva forventer du i brutto årsinntekt til neste år?',
     'inntektenDin.naeringsinntekt.arbeidsinntektIAar.etterDoedsfall.beskrivelse':
         'Skriv hva du forventer å ha i næringsinntekt fra samme måned som dødsfallet til desember.',
-    'inntektenDin.naeringsinntekt.norge.arbeidsinntektIAar.aarsinntekt':
+    'inntektenDin.naeringsinntekt.arbeidsinntektIAar.aarsinntekt':
         'Hva forventer du å ha i brutto næringsinntekt i år?',
+    'inntektenDin.naeringsinntekt.sesongbasertNaeringsinntekt.svar': 'Er arbeidet sesongbasert?',
+    'inntektenDin.naeringsinntekt.sesongbasertNaeringsinntekt.beskrivelse': 'Gi en kort beskrivelse av arbeidet',
     'inntektenDin.naeringsinntekt.forventerEndringAvInntekt.svar':
         'Regner du med at inntekten din endrer seg fremover i tid?',
     'inntektenDin.naeringsinntekt.forventerEndringAvInntekt.grunn': 'Hva er grunnen til endringene?',

--- a/apps/omstillingsstoenad-ui/src/locales/nb.ts
+++ b/apps/omstillingsstoenad-ui/src/locales/nb.ts
@@ -270,6 +270,13 @@ export default {
         'Hvis inntekten din endrer seg etter du har sendt inn søknaden, må du melde fra om endringen til oss.',
     'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.tittel': 'Arbeidsinntekten din året før dødsfallet',
     'inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer': 'Hva var brutto årsinntekt året før dødsfallet?',
+    'inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer.doedsfallAaretFoer':
+        'Hva var brutto årsinntekt i dødsfallsåret?',
+    'inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse':
+        'Fra januar til og med desember',
+    'inntektenDin.loennsinntekt.norge.inntektEtterDoedsfall': 'Hva hadde du i arbeidsinntekt etter dødsfallet?',
+    'inntektenDin.loennsinntekt.norge.inntektEtterDoedsfall.beskrivelse':
+        'Fra måneden etter dødsfallet til og med desember det året. Hvis dødsfallmåneden var desember, oppgir du 0 kroner.',
     'inntektenDin.loennsinntekt.utland.arbeidsinntektAaretFoer': 'Hva var brutto årsinntekt året før dødsfallet?',
     'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.beskrivelse':
         'Dersom fastsettelsen av inntekten fra Skatteetaten ikke er tilgjengelig ennå, kan du oppgi totalinntekten som vises på lønnsslippen for desember.',
@@ -285,6 +292,8 @@ export default {
         'Hva forventer du i brutto årsinntekt til neste år?',
     'inntektenDin.loennsinntekt.utland.arbeidsinntektIAar.etterDoedsfall':
         'Hva forventer du i brutto årsinntekt til neste år?',
+    'inntektenDin.loennsinntekt.norge.arbeidsinntektIAar.aarsinntekt':
+        'Hva forventer du å ha i brutto arbeidsinntekt i år?',
     'inntektenDin.loennsinntekt.forventerEndringAvInntekt.svar':
         'Regner du med at inntekten din endrer seg fremover i tid?',
     'inntektenDin.loennsinntekt.forventerEndringAvInntekt.grunn': 'Hva er grunnen til endringene?',
@@ -299,6 +308,9 @@ export default {
         'Hvis inntekten din endrer seg etter du har sendt inn søknaden, må du melde fra om endringen til oss.',
     'inntektenDin.naeringsinntekt.norge.arbeidsinntektAaretFoer': 'Hva var brutto årsinntekt året før dødsfallet?',
     'inntektenDin.naeringsinntekt.utland.arbeidsinntektAaretFoer': 'Hva var brutto årsinntekt året før dødsfallet?',
+    'inntektenDin.naeringsinntekt.norge.arbeidsinntektAaretFoer.doedsfallAaretFoer':
+        'Hva var brutto årsinntekt i dødsfallsåret?',
+    'inntektenDin.naeringsinntekt.norge.inntektEtterDoedsfall': 'Hva hadde du i næringsinntekt etter dødsfallet?',
     'inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.beskrivelse':
         'Dersom fastsettelsen av inntekten fra Skatteetaten ikke er tilgjengelig ennå, må du anslå næringsinntekten.',
     'inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.beskrivelse.utland':
@@ -313,6 +325,8 @@ export default {
         'Hva forventer du i brutto årsinntekt til neste år?',
     'inntektenDin.naeringsinntekt.arbeidsinntektIAar.etterDoedsfall.beskrivelse':
         'Skriv hva du forventer å ha i næringsinntekt fra samme måned som dødsfallet til desember.',
+    'inntektenDin.naeringsinntekt.norge.arbeidsinntektIAar.aarsinntekt':
+        'Hva forventer du å ha i brutto næringsinntekt i år?',
     'inntektenDin.naeringsinntekt.forventerEndringAvInntekt.svar':
         'Regner du med at inntekten din endrer seg fremover i tid?',
     'inntektenDin.naeringsinntekt.forventerEndringAvInntekt.grunn': 'Hva er grunnen til endringene?',
@@ -401,9 +415,9 @@ export default {
     'omDenAvdoede.fornavn': 'Fornavn',
     'omDenAvdoede.etternavn': 'Etternavn',
     'omDenAvdoede.datoForDoedsfallet': 'Når skjedde dødsfallet?',
-    "omDenAvdoede.datoForDoedsfallet.foerDesember": "Siden dødsfallet skjedde før desember 2023, må du søke om ",
-    "omDenAvdoede.datoForDoedsfallet.foerDesember.link": "gjenlevendepensjon.",
-    "omDenAvdoede.datoForDoedsfallet.foerDesember.href": "https://www.nav.no/gjenlevendepensjon",
+    'omDenAvdoede.datoForDoedsfallet.foerDesember': 'Siden dødsfallet skjedde før desember 2023, må du søke om ',
+    'omDenAvdoede.datoForDoedsfallet.foerDesember.link': 'gjenlevendepensjon.',
+    'omDenAvdoede.datoForDoedsfallet.foerDesember.href': 'https://www.nav.no/gjenlevendepensjon',
     'omDenAvdoede.foedselsnummer': 'Fødselsnummer / d-nummer',
     'omDenAvdoede.statsborgerskap': 'Statsborgerskap',
     'omDenAvdoede.statsborgerskapPlaceholder': 'For eksempel norsk',

--- a/apps/omstillingsstoenad-ui/src/locales/nb.ts
+++ b/apps/omstillingsstoenad-ui/src/locales/nb.ts
@@ -258,7 +258,7 @@ export default {
     'inntektenDin.tittel': 'Inntekten din',
     'inntektenDin.undertittel': 'Inntekt, pensjon og andre utbetalinger i Norge og i utlandet',
     'inntektenDin.ingress':
-        'Hvor mye du kan få i omstillingsstønad avhenger av arbeidsinntekten din. Likestilt med arbeidsinntekt regnes også noen ytelser fra NAV. \n\n Det er viktig at du opplyser oss om brutto inntekt. Brutto arbeidsinntekt betyr inntekten din før skattetrekk. Du finner opplysningene om brutto arbeidsinntekt på lønnslippen din.',
+        'Hvor mye du kan få i omstillingsstønad avhenger av arbeidsinntekten din. Likestilt med arbeidsinntekt regnes også noen ytelser fra NAV. \n\n Det er viktig at du opplyser oss om brutto inntekt. Brutto arbeidsinntekt betyr inntekten din før skattetrekk. Du finner opplysningene om brutto arbeidsinntekt på lønnsslippen din.',
     'inntektenDin.inntektstyper': 'Hvilken type inntekt har du?',
     'inntektenDin.loennsinntekt.tittel': 'Arbeidsinntekt',
     'inntektenDin.loennsinntekt.ingress':
@@ -896,7 +896,7 @@ export default {
     'feil.loennsinntekt.norge.arbeidsinntektIAar.tilDoedsfall.required':
         'Oppgi brutto arbeidsinntekt frem til dødsfallet. Brutto inntekt er inntekten før skatt',
     'feil.loennsinntekt.norge.arbeidsinntektIAar.etterDoedsfall.required':
-        'Oppgi forventet næringsinntekt til neste år. Brutto inntekt er inntekten før skatt\n',
+        'Oppgi forventet næringsinntekt til neste år. Brutto inntekt er inntekten før skatt',
     'feil.loennsinntekt.utland.inntektEtterDoedsfall.required': 'Oppgi arbeidsinntekten din etter dødsfallet',
     'feil.loennsinntekt.utland.arbeidsinntektIAar.aarsinntekt.required': 'Oppgi forventet arbeidsinntekt i år',
     'feil.loennsinntekt.utland.arbeidsinntektAaretFoer.required':

--- a/apps/omstillingsstoenad-ui/src/locales/nb.ts
+++ b/apps/omstillingsstoenad-ui/src/locales/nb.ts
@@ -886,7 +886,7 @@ export default {
     'feil.loennsinntekt.norge.arbeidsinntektIAar.tilDoedsfall.required':
         'Oppgi brutto arbeidsinntekt frem til dødsfallet. Brutto inntekt er inntekten før skatt',
     'feil.loennsinntekt.norge.arbeidsinntektIAar.etterDoedsfall.required':
-        'Oppgi brutto arbeidsinntekt etter dødsfallet. Brutto inntekt er inntekten før skatt',
+        'Oppgi forventet næringsinntekt til neste år. Brutto inntekt er inntekten før skatt\n',
     'feil.loennsinntekt.utland.inntektEtterDoedsfall.required':'Oppgi arbeidsinntekten din etter dødsfallet',
     'feil.loennsinntekt.utland.arbeidsinntektIAar.aarsinntekt.required':'Oppgi forventet arbeidsinntekt i år',
     'feil.loennsinntekt.utland.arbeidsinntektAaretFoer.required':
@@ -894,7 +894,7 @@ export default {
     'feil.loennsinntekt.utland.arbeidsinntektIAar.tilDoedsfall.required':
         'Oppgi brutto arbeidsinntekt frem til dødsfallet. Brutto inntekt er inntekten før skatt',
     'feil.loennsinntekt.utland.arbeidsinntektIAar.etterDoedsfall.required':
-        'Oppgi brutto arbeidsinntekt etter dødsfallet. Brutto inntekt er inntekten før skatt',
+        'Oppgi brutto arbeidsinntekt i dødsfallsåret.',
     'feil.loennsinntekt.forventerEndringAvInntekt.svar.required': 'Forventning rundt inntekt må besvares',
     'feil.loennsinntekt.forventerEndringAvInntekt.grunn.required': 'Oppgi grunnen til endringene',
     'feil.loennsinntekt.forventerEndringAvInntekt.annenGrunn.required': 'Beskrivelse av endringene må besvares',

--- a/apps/omstillingsstoenad-ui/src/locales/nn.ts
+++ b/apps/omstillingsstoenad-ui/src/locales/nn.ts
@@ -267,6 +267,14 @@ export default {
     'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.tittel': 'Arbeidsinntekta di året før dødsfallet',
     'inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer': 'Kva var brutto årsinntekt året før dødsfallet?',
     'inntektenDin.loennsinntekt.utland.arbeidsinntektAaretFoer': 'Kva var brutto årsinntekt året før dødsfallet?',
+    'inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer.doedsfallAaretFoer':
+        'Kva var brutto årsinntekt i dødsfallsåret?',
+    'inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse':
+        'Frå januar til og med desember',
+    'inntektenDin.loennsinntekt.norge.inntektEtterDoedsfall': 'Kva hadde du i arbeidsinntekt etter dødsfallet?',
+    'inntektenDin.loennsinntekt.norge.inntektEtterDoedsfall.beskrivelse':
+        'Frå månaden etter dødsfallet til og med desember det året. Hvis dødsfallmånaden var desember, oppgir du 0 kroner.',
+
     'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.beskrivelse':
         'Dersom Skatteetaten ikkje har slåt fast inntekta enno, kan du oppgi årsinntekta som står på lønsslippen for desember.',
     'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.beskrivelse.utland':
@@ -281,6 +289,8 @@ export default {
         'Kva reknar du med å ha i brutto årsinntekt til neste år?',
     'inntektenDin.loennsinntekt.utland.arbeidsinntektIAar.etterDoedsfall':
         'Kva reknar du med å ha i brutto årsinntekt til neste år?',
+    'inntektenDin.loennsinntekt.norge.arbeidsinntektIAar.aarsinntekt':
+        'Kva reknar du med å ha i brutto arbeidsinntekt i år?',
     'inntektenDin.loennsinntekt.forventerEndringAvInntekt.svar':
         'Går du ut frå at inntekta di vil endre seg fram i tid?',
     'inntektenDin.loennsinntekt.forventerEndringAvInntekt.grunn': 'Kva er grunnen til endringane?',
@@ -295,6 +305,9 @@ export default {
         'Dersom inntekta di endrar seg etter at du har sendt inn søknaden, må du melde frå til oss om endringa.',
     'inntektenDin.naeringsinntekt.norge.arbeidsinntektAaretFoer': 'Kva var brutto årsinntekt året før dødsfallet?',
     'inntektenDin.naeringsinntekt.utland.arbeidsinntektAaretFoer': 'Kva var brutto årsinntekt året før dødsfallet?',
+    'inntektenDin.naeringsinntekt.norge.arbeidsinntektAaretFoer.doedsfallAaretFoer':
+        'Kva var brutto årsinntekt i dødsfallsåret?',
+    'inntektenDin.naeringsinntekt.norge.inntektEtterDoedsfall': 'Kva hadde du i næringsinntekt etter dødsfallet?',
     'inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.beskrivelse':
         'Dersom Skatteetaten ikkje har slått fast inntekta enno, anslår du næringsinntekta sjølv.',
     'inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.beskrivelse.utland':
@@ -309,6 +322,8 @@ export default {
         'Kva reknar du med å ha i brutto årsinntekt til neste år?',
     'inntektenDin.naeringsinntekt.arbeidsinntektIAar.etterDoedsfall.beskrivelse':
         'Skriv kva du reknar med å ha i næringsinntekt frå same månad som dødsfallet og fram til desember.',
+    'inntektenDin.naeringsinntekt.norge.arbeidsinntektIAar.aarsinntekt':
+        'Kva reknar du å ha i brutto næringsinntekt i år?',
     'inntektenDin.naeringsinntekt.forventerEndringAvInntekt.svar':
         'Går du ut frå at inntekta di vil endre seg fram i tid?',
     'inntektenDin.naeringsinntekt.forventerEndringAvInntekt.grunn': 'Kva er grunnen til endringane?',

--- a/apps/omstillingsstoenad-ui/src/locales/nn.ts
+++ b/apps/omstillingsstoenad-ui/src/locales/nn.ts
@@ -271,6 +271,8 @@ export default {
         'Kva var brutto årsinntekt det året dødsfallet skjedde?',
     'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse':
         'Dersom Skatteetaten ikkje har slått fast inntekta enno, kan du oppgi årsinntekta som står på lønsslippen for desember.',
+    'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse.utland':
+        'Dersom Skatteetaten ikkje har slått fast inntekta enno, anslår du næringsinntekta for året.',
     'inntektenDin.loennsinntekt.inntektEtterDoedsfall': 'Kva hadde du i arbeidsinntekt etter dødsfallet?',
     'inntektenDin.loennsinntekt.inntektEtterDoedsfall.beskrivelse':
         'Frå månaden etter dødsfallet til og med desember det året. Hvis dødsfallmånaden var desember, oppgir du 0 kroner.',

--- a/apps/omstillingsstoenad-ui/src/locales/nn.ts
+++ b/apps/omstillingsstoenad-ui/src/locales/nn.ts
@@ -270,7 +270,7 @@ export default {
     'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer':
         'Kva var brutto årsinntekt det året dødsfallet skjedde?',
     'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse':
-        'Oppgi frå januar til og med desember',
+        'Dersom Skatteetaten ikkje har slått fast inntekta enno, kan du oppgi årsinntekta som står på lønsslippen for desember.',
     'inntektenDin.loennsinntekt.inntektEtterDoedsfall': 'Kva hadde du i arbeidsinntekt etter dødsfallet?',
     'inntektenDin.loennsinntekt.inntektEtterDoedsfall.beskrivelse':
         'Frå månaden etter dødsfallet til og med desember det året. Hvis dødsfallmånaden var desember, oppgir du 0 kroner.',
@@ -283,7 +283,7 @@ export default {
     'inntektenDin.loennsinntekt.utland.arbeidsinntektIAar.tilDoedsfall':
         'Kva var brutto arbeidsinntekt fram til dødsfallet?',
     'inntektenDin.loennsinntekt.arbeidsinntektIAar.tilDoedsfall.beskrivelse':
-        'Oppgi inntekt frå januar til og med same månad som dødsfallet. Dersom dødsfallet skjedde i desember, oppgir du heile årsinntekta',
+        'Oppgi inntekt frå januar til og med same månad som dødsfallet. Dersom dødsfallet skjedde i desember, oppgir du heile årsinntekta.',
     'inntektenDin.loennsinntekt.norge.arbeidsinntektIAar.etterDoedsfall':
         'Kva reknar du med å ha i brutto årsinntekt til neste år?',
     'inntektenDin.loennsinntekt.utland.arbeidsinntektIAar.etterDoedsfall':
@@ -323,6 +323,8 @@ export default {
         'Skriv kva du reknar med å ha i næringsinntekt frå same månad som dødsfallet og fram til desember.',
     'inntektenDin.naeringsinntekt.arbeidsinntektIAar.aarsinntekt': 'Kva brutto næringsinntekt reknar du med å ha i år?',
     'inntektenDin.naeringsinntekt.sesongbasertNaeringsinntekt.svar': 'Er arbeidet sesongbasert?',
+    'inntektenDin.naeringsinntekt.sesongbasertNaeringsinntekt.svar.beskrivelse':
+        'Vi treng å vite om næringsinntekta blir tent opp jamt utover året.',
     'inntektenDin.naeringsinntekt.sesongbasertNaeringsinntekt.beskrivelse': 'Beskriv kort arbeidet',
     'inntektenDin.naeringsinntekt.forventerEndringAvInntekt.svar':
         'Går du ut frå at inntekta di vil endre seg fram i tid?',

--- a/apps/omstillingsstoenad-ui/src/locales/nn.ts
+++ b/apps/omstillingsstoenad-ui/src/locales/nn.ts
@@ -887,6 +887,10 @@ export default {
         'Oppgi brutto arbeidsinntekt året før dødsfallet. Brutto inntekt er inntekta før skatt',
     'feil.loennsinntekt.utland.arbeidsinntektAaretFoer.required':
         'Oppgi brutto arbeidsinntekt året før dødsfallet. Brutto inntekt er inntekta før skatt',
+    'feil.loennsinntekt.utland.arbeidsinntektDoedsfallsaaret.required':
+        'Oppgi brutto arbeidsinntekt i året dødsfallet skjedde. Brutto inntekt er inntekta før skatt',
+    'feil.loennsinntekt.norge.arbeidsinntektDoedsfallsaaret.required':
+        'Oppgi brutto arbeidsinntekt i året dødsfallet skjedde. Brutto inntekt er inntekta før skatt',
     'feil.loennsinntekt.norge.arbeidsinntektIAar.tilDoedsfall.required':
         'Oppgi brutto arbeidsinntekt fram til dødsfallet. Brutto inntekt er inntekta før skatt',
     'feil.loennsinntekt.utland.arbeidsinntektIAar.tilDoedsfall.required':
@@ -903,6 +907,10 @@ export default {
         'Oppgi brutto næringsinntekt året før dødsfallet. Brutto inntekt er inntekta før skatt',
     'feil.naeringsinntekt.utland.arbeidsinntektAaretFoer.required':
         'Oppgi brutto næringsinntekt året før dødsfallet. Brutto inntekt er inntekta før skatt',
+    'feil.naeringsinntekt.utland.arbeidsinntektDoedsfallsaaret.required':
+        'Oppgi brutto årsinntekt i året dødsfallet skjedde. Brutto inntekt er inntekta før skatt',
+    'feil.naeringsinntekt.norge.arbeidsinntektDoedsfallsaaret.required':
+        'Oppgi brutto årsinntekt i året dødsfallet skjedde. Brutto inntekt er inntekta før skatt',
     'feil.naeringsinntekt.norge.arbeidsinntektIAar.tilDoedsfall.required':
         'Oppgi brutto næringsinntekt fram til dødsfallet. Brutto inntekt er inntekta før skatt',
     'feil.naeringsinntekt.utland.arbeidsinntektIAar.tilDoedsfall.required':

--- a/apps/omstillingsstoenad-ui/src/locales/nn.ts
+++ b/apps/omstillingsstoenad-ui/src/locales/nn.ts
@@ -272,7 +272,7 @@ export default {
     'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse':
         'Dersom Skatteetaten ikkje har slått fast inntekta enno, kan du oppgi årsinntekta som står på lønsslippen for desember.',
     'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse.utland':
-        'Dersom Skatteetaten ikkje har slått fast inntekta enno, anslår du næringsinntekta for året.',
+        'Dersom du ikkje veit inntekta for dette året, kan du oppgi årsinntekta som står på lønsslippen for desember.',
     'inntektenDin.loennsinntekt.inntektEtterDoedsfall': 'Kva hadde du i arbeidsinntekt etter dødsfallet?',
     'inntektenDin.loennsinntekt.inntektEtterDoedsfall.beskrivelse':
         'Frå månaden etter dødsfallet til og med desember det året. Hvis dødsfallmånaden var desember, oppgir du 0 kroner.',
@@ -314,7 +314,7 @@ export default {
     'inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.beskrivelse':
         'Dersom Skatteetaten ikkje har slått fast inntekta enno, anslår du næringsinntekta sjølv.',
     'inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.beskrivelse.utland':
-        'Dersom du ikkje kjenne inntekta dette året, anslår du næringsinntekta sjølv.',
+        'Viss du ikkje veit kva som var inntekta det året, anslår du næringsinntekta.',
     'inntektenDin.naeringsinntekt.norge.arbeidsinntektIAar.tilDoedsfall': 'Kva er brutto næringsinntekt i år?',
     'inntektenDin.naeringsinntekt.utland.arbeidsinntektIAar.tilDoedsfall': 'Kva er brutto næringsinntekt i år?',
     'inntektenDin.naeringsinntekt.arbeidsinntektIAar.tilDoedsfall.beskrivelse':

--- a/apps/omstillingsstoenad-ui/src/locales/nn.ts
+++ b/apps/omstillingsstoenad-ui/src/locales/nn.ts
@@ -267,14 +267,13 @@ export default {
     'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.tittel': 'Arbeidsinntekta di året før dødsfallet',
     'inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer': 'Kva var brutto årsinntekt året før dødsfallet?',
     'inntektenDin.loennsinntekt.utland.arbeidsinntektAaretFoer': 'Kva var brutto årsinntekt året før dødsfallet?',
-    'inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer.doedsfallAaretFoer':
+    'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer':
         'Kva var brutto årsinntekt i dødsfallsåret?',
-    'inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse':
+    'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse':
         'Frå januar til og med desember',
-    'inntektenDin.loennsinntekt.norge.inntektEtterDoedsfall': 'Kva hadde du i arbeidsinntekt etter dødsfallet?',
-    'inntektenDin.loennsinntekt.norge.inntektEtterDoedsfall.beskrivelse':
+    'inntektenDin.loennsinntekt.inntektEtterDoedsfall': 'Kva hadde du i arbeidsinntekt etter dødsfallet?',
+    'inntektenDin.loennsinntekt.inntektEtterDoedsfall.beskrivelse':
         'Frå månaden etter dødsfallet til og med desember det året. Hvis dødsfallmånaden var desember, oppgir du 0 kroner.',
-
     'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.beskrivelse':
         'Dersom Skatteetaten ikkje har slåt fast inntekta enno, kan du oppgi årsinntekta som står på lønsslippen for desember.',
     'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.beskrivelse.utland':
@@ -289,7 +288,7 @@ export default {
         'Kva reknar du med å ha i brutto årsinntekt til neste år?',
     'inntektenDin.loennsinntekt.utland.arbeidsinntektIAar.etterDoedsfall':
         'Kva reknar du med å ha i brutto årsinntekt til neste år?',
-    'inntektenDin.loennsinntekt.norge.arbeidsinntektIAar.aarsinntekt':
+    'inntektenDin.loennsinntekt.arbeidsinntektIAar.aarsinntekt':
         'Kva reknar du med å ha i brutto arbeidsinntekt i år?',
     'inntektenDin.loennsinntekt.forventerEndringAvInntekt.svar':
         'Går du ut frå at inntekta di vil endre seg fram i tid?',

--- a/apps/omstillingsstoenad-ui/src/locales/nn.ts
+++ b/apps/omstillingsstoenad-ui/src/locales/nn.ts
@@ -306,6 +306,8 @@ export default {
     'inntektenDin.naeringsinntekt.utland.arbeidsinntektAaretFoer': 'Kva var brutto årsinntekt året før dødsfallet?',
     'inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer':
         'Kva var brutto årsinntekt det året dødsfallet skjedde?',
+    'inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse':
+        'Dersom Skatteetaten ikkje har slått fast inntekta enno, anslår du næringsinntekta for året.',
     'inntektenDin.naeringsinntekt.norge.inntektEtterDoedsfall': 'Kva hadde du i næringsinntekt etter dødsfallet?',
     'inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.beskrivelse':
         'Dersom Skatteetaten ikkje har slått fast inntekta enno, anslår du næringsinntekta sjølv.',

--- a/apps/omstillingsstoenad-ui/src/locales/nn.ts
+++ b/apps/omstillingsstoenad-ui/src/locales/nn.ts
@@ -268,9 +268,9 @@ export default {
     'inntektenDin.loennsinntekt.norge.arbeidsinntektAaretFoer': 'Kva var brutto årsinntekt året før dødsfallet?',
     'inntektenDin.loennsinntekt.utland.arbeidsinntektAaretFoer': 'Kva var brutto årsinntekt året før dødsfallet?',
     'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer':
-        'Kva var brutto årsinntekt i dødsfallsåret?',
+        'Kva var brutto årsinntekt det året dødsfallet skjedde?',
     'inntektenDin.loennsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer.beskrivelse':
-        'Frå januar til og med desember',
+        'Oppgi frå januar til og med desember',
     'inntektenDin.loennsinntekt.inntektEtterDoedsfall': 'Kva hadde du i arbeidsinntekt etter dødsfallet?',
     'inntektenDin.loennsinntekt.inntektEtterDoedsfall.beskrivelse':
         'Frå månaden etter dødsfallet til og med desember det året. Hvis dødsfallmånaden var desember, oppgir du 0 kroner.',
@@ -289,7 +289,7 @@ export default {
     'inntektenDin.loennsinntekt.utland.arbeidsinntektIAar.etterDoedsfall':
         'Kva reknar du med å ha i brutto årsinntekt til neste år?',
     'inntektenDin.loennsinntekt.arbeidsinntektIAar.aarsinntekt': 'Kva reknar du med å ha i brutto arbeidsinntekt i år?',
-    'inntektenDin.loennsinntekt.arbeidsinntektIAar.aarsinntekt.beskrivelse': 'Oppgi fra januar til og med desember.',
+    'inntektenDin.loennsinntekt.arbeidsinntektIAar.aarsinntekt.beskrivelse': 'Oppgi frå januar til og med desember.',
     'inntektenDin.loennsinntekt.forventerEndringAvInntekt.svar':
         'Går du ut frå at inntekta di vil endre seg fram i tid?',
     'inntektenDin.loennsinntekt.forventerEndringAvInntekt.grunn': 'Kva er grunnen til endringane?',
@@ -305,7 +305,7 @@ export default {
     'inntektenDin.naeringsinntekt.norge.arbeidsinntektAaretFoer': 'Kva var brutto årsinntekt året før dødsfallet?',
     'inntektenDin.naeringsinntekt.utland.arbeidsinntektAaretFoer': 'Kva var brutto årsinntekt året før dødsfallet?',
     'inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer':
-        'Kva var brutto årsinntekt i dødsfallsåret?',
+        'Kva var brutto årsinntekt det året dødsfallet skjedde?',
     'inntektenDin.naeringsinntekt.norge.inntektEtterDoedsfall': 'Kva hadde du i næringsinntekt etter dødsfallet?',
     'inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.beskrivelse':
         'Dersom Skatteetaten ikkje har slått fast inntekta enno, anslår du næringsinntekta sjølv.',
@@ -321,9 +321,9 @@ export default {
         'Kva reknar du med å ha i brutto årsinntekt til neste år?',
     'inntektenDin.naeringsinntekt.arbeidsinntektIAar.etterDoedsfall.beskrivelse':
         'Skriv kva du reknar med å ha i næringsinntekt frå same månad som dødsfallet og fram til desember.',
-    'inntektenDin.naeringsinntekt.arbeidsinntektIAar.aarsinntekt': 'Kva reknar du å ha i brutto næringsinntekt i år?',
+    'inntektenDin.naeringsinntekt.arbeidsinntektIAar.aarsinntekt': 'Kva brutto næringsinntekt reknar du med å ha i år?',
     'inntektenDin.naeringsinntekt.sesongbasertNaeringsinntekt.svar': 'Er arbeidet sesongbasert?',
-    'inntektenDin.naeringsinntekt.sesongbasertNaeringsinntekt.beskrivelse': 'Gi en kort beskrivelse av arbeidet',
+    'inntektenDin.naeringsinntekt.sesongbasertNaeringsinntekt.beskrivelse': 'Beskriv kort arbeidet',
     'inntektenDin.naeringsinntekt.forventerEndringAvInntekt.svar':
         'Går du ut frå at inntekta di vil endre seg fram i tid?',
     'inntektenDin.naeringsinntekt.forventerEndringAvInntekt.grunn': 'Kva er grunnen til endringane?',

--- a/apps/omstillingsstoenad-ui/src/locales/nn.ts
+++ b/apps/omstillingsstoenad-ui/src/locales/nn.ts
@@ -533,7 +533,7 @@ export default {
     'soeknadKvittering.seSaken.informasjon.lenkeMittNAV.tekst': 'mitt NAV.',
     'soeknadKvittering.seSaken.informasjon.innhold2': 'Lurer du på kor lang tid behandlinga vil ta? Her kan du sjå',
     'soeknadKvittering.seSaken.informasjon.lenkeSaksbehandlingstid.href': 'https://www.nav.no/saksbehandlingstider',
-    'soeknadKvittering.seSaken.informasjon.lenkeSaksbehandlingstid.tekst': 'forventet saksbehandlingstid.',
+    'soeknadKvittering.seSaken.informasjon.lenkeSaksbehandlingstid.tekst': 'forventa saksbehandlingstid.',
     'soeknadKvittering.andreStoenader.tittel': 'Du kan også ha rett til andre stønader',
     'soeknadKvittering.andreStoenader.informasjon':
         'Er du under utdanning, søkjer du jobb eller har de barn? Då kan du også ha rett på andre støtteordningar som til dømes barnepass eller dekking av utgifter du har i samband med utdanning eller jobbsøk.',
@@ -872,6 +872,11 @@ export default {
     'feil.utbetalingsInformasjon.swift.validate': 'Ugyldig SWIFT/BIC kode',
     'feil.inntektstyper.required': 'Oppgi kva inntektstype du har',
     'feil.loennsinntekt.norgeEllerUtland.required': 'Du må krysse av for kor du får arbeidsinntekt frå',
+    'feil.loennsinntekt.norge.inntektEtterDoedsfall.required': 'Oppgi arbeidsinntekta din etter dødsfallet',
+    'feil.loennsinntekt.norge.arbeidsinntektIAar.aarsinntekt.required': 'Oppgi arbeidsinntekta du reknar med å ha i år',
+    'feil.loennsinntekt.utland.inntektEtterDoedsfall.required': 'Oppgi arbeidsinntekta din etter dødsfallet',
+    'feil.loennsinntekt.utland.arbeidsinntektIAar.aarsinntekt.required':
+        'Oppgi arbeidsinntekta du reknar med å ha i år',
     'feil.loennsinntekt.norge.arbeidsinntektAaretFoer.required':
         'Oppgi brutto arbeidsinntekt året før dødsfallet. Brutto inntekt er inntekta før skatt',
     'feil.loennsinntekt.utland.arbeidsinntektAaretFoer.required':
@@ -900,9 +905,18 @@ export default {
         'Oppgi brutto næringsinntekt etter dødsfallet. Brutto inntekt er inntekta før skatt',
     'feil.naeringsinntekt.utland.arbeidsinntektIAar.etterDoedsfall.required':
         'Oppgi brutto næringsinntekt etter dødsfallet. Brutto inntekt er inntekta før skatt',
+    'feil.naeringsinntekt.norge.arbeidsinntektIAar.aarsinntekt.required': 'Oppgi forventa næringsinntekt i år',
+    'feil.naeringsinntekt.utland.arbeidsinntektIAar.aarsinntekt.required': 'Oppgi forventa næringsinntekt i år',
     'feil.naeringsinntekt.forventerEndringAvInntekt.svar.required': 'Svar på spørsmålet om forventing rundt inntekt',
     'feil.naeringsinntekt.forventerEndringAvInntekt.grunn.required': 'Oppgi grunnen til endringane',
     'feil.naeringsinntekt.forventerEndringAvInntekt.annenGrunn.required': 'Du må beskrive endringane',
+    'feil.naeringsinntekt.norge.sesongbasertNaeringsinntekt.svar.required':
+        'Du må velje om arbeidet er sesongbasert eller ikkje',
+    'feil.naeringsinntekt.norge.sesongbasertNaeringsinntekt.beskrivelse.required': 'Gi en kort beskrivelse av arbeidet',
+    'feil.naeringsinntekt.utland.sesongbasertNaeringsinntekt.svar.required':
+        'Du må velje om arbeidet er sesongbasert eller ikkje',
+    'feil.naeringsinntekt.utland.sesongbasertNaeringsinntekt.beskrivelse.required':
+        'Gi en kort beskrivelse av arbeidet',
     'feil.pensjonEllerUfoere.pensjonstype.required': 'Oppgi kva pensjon eller trygd du har',
     'feil.pensjonEllerUfoere.tjenestepensjonsordning.type.required': 'Vel kva pensjon du får',
     'feil.pensjonEllerUfoere.tjenestepensjonsordning.utbetaler.required':

--- a/apps/omstillingsstoenad-ui/src/locales/nn.ts
+++ b/apps/omstillingsstoenad-ui/src/locales/nn.ts
@@ -288,8 +288,8 @@ export default {
         'Kva reknar du med å ha i brutto årsinntekt til neste år?',
     'inntektenDin.loennsinntekt.utland.arbeidsinntektIAar.etterDoedsfall':
         'Kva reknar du med å ha i brutto årsinntekt til neste år?',
-    'inntektenDin.loennsinntekt.arbeidsinntektIAar.aarsinntekt':
-        'Kva reknar du med å ha i brutto arbeidsinntekt i år?',
+    'inntektenDin.loennsinntekt.arbeidsinntektIAar.aarsinntekt': 'Kva reknar du med å ha i brutto arbeidsinntekt i år?',
+    'inntektenDin.loennsinntekt.arbeidsinntektIAar.aarsinntekt.beskrivelse': 'Oppgi fra januar til og med desember.',
     'inntektenDin.loennsinntekt.forventerEndringAvInntekt.svar':
         'Går du ut frå at inntekta di vil endre seg fram i tid?',
     'inntektenDin.loennsinntekt.forventerEndringAvInntekt.grunn': 'Kva er grunnen til endringane?',
@@ -304,7 +304,7 @@ export default {
         'Dersom inntekta di endrar seg etter at du har sendt inn søknaden, må du melde frå til oss om endringa.',
     'inntektenDin.naeringsinntekt.norge.arbeidsinntektAaretFoer': 'Kva var brutto årsinntekt året før dødsfallet?',
     'inntektenDin.naeringsinntekt.utland.arbeidsinntektAaretFoer': 'Kva var brutto årsinntekt året før dødsfallet?',
-    'inntektenDin.naeringsinntekt.norge.arbeidsinntektAaretFoer.doedsfallAaretFoer':
+    'inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.doedsfallAaretFoer':
         'Kva var brutto årsinntekt i dødsfallsåret?',
     'inntektenDin.naeringsinntekt.norge.inntektEtterDoedsfall': 'Kva hadde du i næringsinntekt etter dødsfallet?',
     'inntektenDin.naeringsinntekt.arbeidsinntektAaretFoer.beskrivelse':
@@ -321,8 +321,9 @@ export default {
         'Kva reknar du med å ha i brutto årsinntekt til neste år?',
     'inntektenDin.naeringsinntekt.arbeidsinntektIAar.etterDoedsfall.beskrivelse':
         'Skriv kva du reknar med å ha i næringsinntekt frå same månad som dødsfallet og fram til desember.',
-    'inntektenDin.naeringsinntekt.norge.arbeidsinntektIAar.aarsinntekt':
-        'Kva reknar du å ha i brutto næringsinntekt i år?',
+    'inntektenDin.naeringsinntekt.arbeidsinntektIAar.aarsinntekt': 'Kva reknar du å ha i brutto næringsinntekt i år?',
+    'inntektenDin.naeringsinntekt.sesongbasertNaeringsinntekt.svar': 'Er arbeidet sesongbasert?',
+    'inntektenDin.naeringsinntekt.sesongbasertNaeringsinntekt.beskrivelse': 'Gi en kort beskrivelse av arbeidet',
     'inntektenDin.naeringsinntekt.forventerEndringAvInntekt.svar':
         'Går du ut frå at inntekta di vil endre seg fram i tid?',
     'inntektenDin.naeringsinntekt.forventerEndringAvInntekt.grunn': 'Kva er grunnen til endringane?',

--- a/apps/omstillingsstoenad-ui/src/typer/inntekt.ts
+++ b/apps/omstillingsstoenad-ui/src/typer/inntekt.ts
@@ -37,9 +37,11 @@ export interface ILoennsinntekt {
 
 export interface IInntekter {
     arbeidsinntektAaretFoer?: string
+    inntektEtterDoedsfall?: string
     arbeidsinntektIAar?: {
         tilDoedsfall?: string
         etterDoedsfall?: string
+        aarsinntekt?: string
     }
 }
 

--- a/apps/omstillingsstoenad-ui/src/typer/inntekt.ts
+++ b/apps/omstillingsstoenad-ui/src/typer/inntekt.ts
@@ -43,6 +43,10 @@ export interface IInntekter {
         etterDoedsfall?: string
         aarsinntekt?: string
     }
+    sesongbasertNaeringsinntekt?: {
+        svar?: IValg
+        beskrivelse?: string
+    }
 }
 
 export interface IPensjonEllerUfoere {

--- a/apps/omstillingsstoenad-ui/src/typer/inntekt.ts
+++ b/apps/omstillingsstoenad-ui/src/typer/inntekt.ts
@@ -37,6 +37,7 @@ export interface ILoennsinntekt {
 
 export interface IInntekter {
     arbeidsinntektAaretFoer?: string
+    arbeidsinntektDoedsfallsaaret?: string
     inntektEtterDoedsfall?: string
     arbeidsinntektIAar?: {
         tilDoedsfall?: string

--- a/apps/omstillingsstoenad-ui/src/utils/dato.test.js
+++ b/apps/omstillingsstoenad-ui/src/utils/dato.test.js
@@ -1,4 +1,10 @@
-import { antallAarMellom, erDato, erMellomOktoberogDesember, ugyldigPeriodeFraSamlivsbruddTilDoedsfall } from './dato'
+import {
+    antallAarMellom,
+    doedsdatoErIAar,
+    erDato,
+    erMellomOktoberogDesember,
+    ugyldigPeriodeFraSamlivsbruddTilDoedsfall,
+} from './dato'
 
 describe('Verifiser gyldighet av periode mellom samlivsbrudd og dødsfall', () => {
     it('Mer enn fem år mellom samlivsbrudd og dødsfall', () => {
@@ -154,5 +160,23 @@ describe('Funksjon erMellomOktoberOgDesember fungerer som forventet', () => {
     it('Skal returnere false hvis idag er 30. september', () => {
         jest.setSystemTime(new Date(2020, 8, 30))
         expect(erMellomOktoberogDesember()).toBeFalsy()
+    })
+})
+
+describe('Funksjon doedsdatoErIAar fungerer som forventet', () => {
+    it('Skal returnere true hvis dato for dødsfall er idag', () => {
+        expect(doedsdatoErIAar(new Date())).toBeTruthy()
+    })
+
+    it('Skal returnere false hvis dato for dødsfall er neste år', () => {
+        const nesteAar = new Date()
+        nesteAar.setFullYear(nesteAar.getFullYear() + 1)
+        expect(doedsdatoErIAar(nesteAar)).toBeFalsy()
+    })
+
+    it('Skal returnere false hvis dato for dødsfall er året før', () => {
+        const aaretFoer = new Date()
+        aaretFoer.setFullYear(aaretFoer.getFullYear() - 1)
+        expect(doedsdatoErIAar(aaretFoer)).toBeFalsy()
     })
 })

--- a/apps/omstillingsstoenad-ui/src/utils/dato.ts
+++ b/apps/omstillingsstoenad-ui/src/utils/dato.ts
@@ -43,11 +43,23 @@ export const ugyldigPeriodeFraSamlivsbruddTilDoedsfall = (
     return !!aarMellomSamlivsbruddOgDoed && aarMellomSamlivsbruddOgDoed >= 5
 }
 
-export const erMellomOktoberogDesember = () => {
+export const erMellomOktoberogDesember = (): boolean => {
     const idag = new Date()
     idag.setHours(12, 0, 0, 0)
+
     const sisteDagIDesember = new Date(idag.getFullYear(), 11, 31)
     sisteDagIDesember.setHours(23, 59, 59, 0)
+
     const foersteDagIOktober = new Date(idag.getFullYear(), 9, 1)
+
     return foersteDagIOktober <= idag && idag <= sisteDagIDesember
+}
+
+export const doedsdatoErIAar = (doedsfall: Date): boolean => {
+    const idag = new Date()
+    idag.setHours(0, 0, 0, 0)
+
+    const doedsfallsDato = new Date(doedsfall)
+
+    return idag.getFullYear() === doedsfallsDato.getFullYear()
 }


### PR DESCRIPTION
Mangler følgende fra andre repoer:
- [x] Oppdatering av data class i common https://github.com/navikt/pensjon-etterlatte-libs/pull/42
- [x] Mapping av brev https://github.com/navikt/pensjon-etterlatte-felles/pull/169

### Arbeidsinntekt
#### Dødsfall i år:
![Skjermbilde 2023-12-20 kl  12 58 44](https://github.com/navikt/pensjon-etterlatte/assets/17142094/d9df6f85-888d-4244-88dc-9f44343d7125)

#### Dødsfall året før:
![Skjermbilde 2023-12-20 kl  12 59 23](https://github.com/navikt/pensjon-etterlatte/assets/17142094/bcfa36d7-5887-4b41-abc1-cf82f2bcf1ad)


### Næringsinntekt
#### Dødsfall i år:
![Skjermbilde 2023-12-20 kl  12 58 31](https://github.com/navikt/pensjon-etterlatte/assets/17142094/3c5f3287-bf7b-4991-b4da-dbcb50c622a2)

#### Dødsfall året før:
![Skjermbilde 2023-12-20 kl  12 59 38](https://github.com/navikt/pensjon-etterlatte/assets/17142094/64f6665f-9791-4244-ad0d-65f5f3cd6921)

