### PR TITLE
Det er unødvendig og sårbart å bruke fullsize-node-baseimaget

### DIFF
--- a/apps/etterlatte-node-server/Dockerfile
+++ b/apps/etterlatte-node-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20
+FROM node:20-bookworm-slim
 
 WORKDIR /usr/src/app
 

--- a/docker/frontend.Dockerfile
+++ b/docker/frontend.Dockerfile
@@ -1,2 +1,2 @@
-FROM europe-north1-docker.pkg.dev/nais-management-233d/etterlatte/pensjon-etterlatte-etterlatte-node-server:main
+FROM europe-north1-docker.pkg.dev/nais-management-233d/etterlatte/pensjon-etterlatte-etterlatte-node-server:2023.12.22-10.32-db4de34
 COPY build ./build

--- a/docker/frontend.Dockerfile
+++ b/docker/frontend.Dockerfile
@@ -1,2 +1,2 @@
-FROM europe-north1-docker.pkg.dev/nais-management-233d/etterlatte/pensjon-etterlatte-etterlatte-node-server:2023.12.22-10.32-db4de34
+FROM europe-north1-docker.pkg.dev/nais-management-233d/etterlatte/pensjon-etterlatte-etterlatte-node-server:main
 COPY build ./build


### PR DESCRIPTION
Det inneheld mykje meir enn vi treng, og er også sårbart.

snyk har ein god post på https://snyk.io/blog/choosing-the-best-node-js-docker-image/ , følgjer rådet derifrå og byttar over til bookworm-slim-varianten, som er eit fullverdig node-miljø og ikkje så mykje meir.

Veldig mange sårbarheiter dependency track rapporterer om kjem frå node-baseimaget: https://console.nav.cloud.nais.io/team/etterlatte/vulnerabilities