### PR TITLE
Capitalize fornavn og etternavn for BP. Fikser skrivefeil i OMS

### DIFF
--- a/apps/barnepensjon-ui/src/hooks/useLoggedInUser.ts
+++ b/apps/barnepensjon-ui/src/hooks/useLoggedInUser.ts
@@ -4,6 +4,7 @@ import { getLoggedInUser } from '../api/api'
 import { ActionTypes, User } from '../context/user/user'
 import { useUserContext } from '../context/user/UserContext'
 import { getAgeFromDate, isLegalAge } from '../utils/age'
+import { capitalize } from '../utils/capitalize'
 
 export default function useLoggedInUser() {
     const navigate = useNavigate()
@@ -20,9 +21,12 @@ export default function useLoggedInUser() {
                 const alder = getAgeFromDate(user.foedselsdato!!)
                 const kanSoeke = isLegalAge(alder)
 
+                const fornavn = capitalize(user.fornavn!!)
+                const etternavn = capitalize(user.etternavn!!)
+
                 dispatch({
                     type: ActionTypes.SET_USER,
-                    payload: { ...user, alder, kanSoeke },
+                    payload: { ...user, fornavn, etternavn, alder, kanSoeke },
                 })
 
                 if (!kanSoeke) navigate('/ugyldig-soeker')

--- a/apps/barnepensjon-ui/src/hooks/useLoggedInUser.ts
+++ b/apps/barnepensjon-ui/src/hooks/useLoggedInUser.ts
@@ -4,7 +4,7 @@ import { getLoggedInUser } from '../api/api'
 import { ActionTypes, User } from '../context/user/user'
 import { useUserContext } from '../context/user/UserContext'
 import { getAgeFromDate, isLegalAge } from '../utils/age'
-import { capitalize } from '../utils/capitalize'
+import { capitalizeName } from '../utils/capitalize'
 
 export default function useLoggedInUser() {
     const navigate = useNavigate()
@@ -21,8 +21,8 @@ export default function useLoggedInUser() {
                 const alder = getAgeFromDate(user.foedselsdato!!)
                 const kanSoeke = isLegalAge(alder)
 
-                const fornavn = capitalize(user.fornavn!!)
-                const etternavn = capitalize(user.etternavn!!)
+                const fornavn = capitalizeName(user.fornavn!!)
+                const etternavn = capitalizeName(user.etternavn!!)
 
                 dispatch({
                     type: ActionTypes.SET_USER,

--- a/apps/barnepensjon-ui/src/utils/capitalize.test.ts
+++ b/apps/barnepensjon-ui/src/utils/capitalize.test.ts
@@ -1,0 +1,31 @@
+import { capitalize } from './capitalize'
+
+describe('Test of capitalize', () => {
+    it('Single word in uppercase is capitalized', () => {
+        const testString = 'TEST'
+        const fasitString = 'Test'
+
+        expect(capitalize(testString)).toStrictEqual(fasitString)
+    })
+
+    it('Two words in uppercase is capitalized', () => {
+        const testString = 'TEST TESTESEN'
+        const fasitString = 'Test Testesen'
+
+        expect(capitalize(testString)).toStrictEqual(fasitString)
+    })
+
+    it('Single word in lowercase is capitalized', () => {
+        const testString = 'test'
+        const fasitString = 'Test'
+
+        expect(capitalize(testString)).toStrictEqual(fasitString)
+    })
+
+    it('Two words in lowercase is capitalized', () => {
+        const testString = 'test testesen'
+        const fasitString = 'Test Testesen'
+
+        expect(capitalize(testString)).toStrictEqual(fasitString)
+    })
+})

--- a/apps/barnepensjon-ui/src/utils/capitalize.test.ts
+++ b/apps/barnepensjon-ui/src/utils/capitalize.test.ts
@@ -1,16 +1,9 @@
-import { capitalize } from './capitalize'
+import { capitalize, capitalizeName } from './capitalize'
 
 describe('Test of capitalize', () => {
     it('Single word in uppercase is capitalized', () => {
         const testString = 'TEST'
         const fasitString = 'Test'
-
-        expect(capitalize(testString)).toStrictEqual(fasitString)
-    })
-
-    it('Two words in uppercase is capitalized', () => {
-        const testString = 'TEST TESTESEN'
-        const fasitString = 'Test Testesen'
 
         expect(capitalize(testString)).toStrictEqual(fasitString)
     })
@@ -21,11 +14,48 @@ describe('Test of capitalize', () => {
 
         expect(capitalize(testString)).toStrictEqual(fasitString)
     })
+})
+
+describe('Test of capitalizeName', () => {
+    it('Single word in uppercase is capitalized', () => {
+        const testString = 'TEST'
+        const fasitString = 'Test'
+
+        expect(capitalizeName(testString)).toStrictEqual(fasitString)
+    })
+
+    it('Two words in uppercase is capitalized', () => {
+        const testString = 'TEST TESTESEN'
+        const fasitString = 'Test Testesen'
+
+        expect(capitalizeName(testString)).toStrictEqual(fasitString)
+    })
+
+    it('"Dobbeltnavn" in uppercase is capitalized', () => {
+        const testString = 'TEST-TESTESEN'
+        const fasitString = 'Test-Testesen'
+
+        expect(capitalizeName(testString)).toStrictEqual(fasitString)
+    })
+
+    it('Single word in lowercase is capitalized', () => {
+        const testString = 'test'
+        const fasitString = 'Test'
+
+        expect(capitalizeName(testString)).toStrictEqual(fasitString)
+    })
 
     it('Two words in lowercase is capitalized', () => {
         const testString = 'test testesen'
         const fasitString = 'Test Testesen'
 
-        expect(capitalize(testString)).toStrictEqual(fasitString)
+        expect(capitalizeName(testString)).toStrictEqual(fasitString)
+    })
+
+    it('"Dobbeltnavn" in lowercase is capitalized', () => {
+        const testString = 'test-testesen'
+        const fasitString = 'Test-Testesen'
+
+        expect(capitalizeName(testString)).toStrictEqual(fasitString)
     })
 })

--- a/apps/barnepensjon-ui/src/utils/capitalize.ts
+++ b/apps/barnepensjon-ui/src/utils/capitalize.ts
@@ -1,0 +1,8 @@
+export const capitalize = (str: string): string => {
+    const strList = str.split(' ')
+    return strList
+        .map((str) => {
+            return str.charAt(0).toUpperCase() + str.toLowerCase().slice(1)
+        })
+        .join(' ')
+}

--- a/apps/barnepensjon-ui/src/utils/capitalize.ts
+++ b/apps/barnepensjon-ui/src/utils/capitalize.ts
@@ -1,8 +1,13 @@
 export const capitalize = (str: string): string => {
-    const strList = str.split(' ')
-    return strList
+    return str.charAt(0).toUpperCase() + str.toLowerCase().slice(1)
+}
+
+export const capitalizeName = (name: string, delim: string = ' '): string => {
+    return name
+        .split(delim)
         .map((str) => {
-            return str.charAt(0).toUpperCase() + str.toLowerCase().slice(1)
+            if (str.includes('-')) return capitalizeName(str, '-')
+            return capitalize(str)
         })
-        .join(' ')
+        .join(delim)
 }

--- a/apps/omstillingsstoenad-ui/src/hooks/useInnloggetBruker.test.js
+++ b/apps/omstillingsstoenad-ui/src/hooks/useInnloggetBruker.test.js
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react'
-import useInnloggetBruker, { captalize } from './useInnloggetBruker'
+import useInnloggetBruker, { capitalize } from './useInnloggetBruker'
 
 const mock = jest.fn(async () => {
     return 'Ok'
@@ -36,27 +36,27 @@ describe('Test av capitalize', () => {
         const testString = 'TEST'
         const fasitString = 'Test'
 
-        expect(captalize(testString)).toStrictEqual(fasitString)
+        expect(capitalize(testString)).toStrictEqual(fasitString)
     })
 
     it('Tester at dobbelt navn i uppercase får stor forbokstav', () => {
         const testString = 'TEST TESTESEN'
         const fasitString = 'Test Testesen'
 
-        expect(captalize(testString)).toStrictEqual(fasitString)
+        expect(capitalize(testString)).toStrictEqual(fasitString)
     })
 
     it('Tester at enkelt navn i lowercase får stor forbokstav', () => {
         const testString = 'test'
         const fasitString = 'Test'
 
-        expect(captalize(testString)).toStrictEqual(fasitString)
+        expect(capitalize(testString)).toStrictEqual(fasitString)
     })
 
     it('Tester at dobbelt navn i lowercase får stor forbokstav', () => {
         const testString = 'test testesen'
         const fasitString = 'Test Testesen'
 
-        expect(captalize(testString)).toStrictEqual(fasitString)
+        expect(capitalize(testString)).toStrictEqual(fasitString)
     })
 })

--- a/apps/omstillingsstoenad-ui/src/hooks/useInnloggetBruker.test.js
+++ b/apps/omstillingsstoenad-ui/src/hooks/useInnloggetBruker.test.js
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react'
-import useInnloggetBruker, { capitalize } from './useInnloggetBruker'
+import useInnloggetBruker from './useInnloggetBruker'
 
 const mock = jest.fn(async () => {
     return 'Ok'
@@ -28,35 +28,5 @@ describe('useInnloggetBruker', () => {
 
         expect(result.current).toBe(true)
         expect(mock).toBeCalledTimes(1)
-    })
-})
-
-describe('Test av capitalize', () => {
-    it('Tester at enkelt navn i uppercase får stor forbokstav', () => {
-        const testString = 'TEST'
-        const fasitString = 'Test'
-
-        expect(capitalize(testString)).toStrictEqual(fasitString)
-    })
-
-    it('Tester at dobbelt navn i uppercase får stor forbokstav', () => {
-        const testString = 'TEST TESTESEN'
-        const fasitString = 'Test Testesen'
-
-        expect(capitalize(testString)).toStrictEqual(fasitString)
-    })
-
-    it('Tester at enkelt navn i lowercase får stor forbokstav', () => {
-        const testString = 'test'
-        const fasitString = 'Test'
-
-        expect(capitalize(testString)).toStrictEqual(fasitString)
-    })
-
-    it('Tester at dobbelt navn i lowercase får stor forbokstav', () => {
-        const testString = 'test testesen'
-        const fasitString = 'Test Testesen'
-
-        expect(capitalize(testString)).toStrictEqual(fasitString)
     })
 })

--- a/apps/omstillingsstoenad-ui/src/hooks/useInnloggetBruker.ts
+++ b/apps/omstillingsstoenad-ui/src/hooks/useInnloggetBruker.ts
@@ -5,15 +5,7 @@ import { hentAlder } from '../utils/dato'
 import { gyldigAlder } from '../utils/alder'
 import { useBrukerContext } from '../context/bruker/BrukerContext'
 import { useNavigate } from 'react-router-dom'
-
-export const capitalize = (str: string): string => {
-    const strList = str.split(' ')
-    return strList
-        .map((str) => {
-            return str.charAt(0).toUpperCase() + str.toLowerCase().slice(1)
-        })
-        .join(' ')
-}
+import { capitalizeName } from '../utils/capitalize'
 
 const useInnloggetBruker = () => {
     const navigate = useNavigate()
@@ -29,8 +21,8 @@ const useInnloggetBruker = () => {
                 const alder = hentAlder(person.foedselsdato!!)
                 const kanSoeke = gyldigAlder(alder)
 
-                const fornavn = capitalize(person.fornavn!!)
-                const etternavn = capitalize(person.etternavn!!)
+                const fornavn = capitalizeName(person.fornavn!!)
+                const etternavn = capitalizeName(person.etternavn!!)
 
                 dispatch({
                     type: BrukerActionTypes.HENT_INNLOGGET_BRUKER,

--- a/apps/omstillingsstoenad-ui/src/hooks/useInnloggetBruker.ts
+++ b/apps/omstillingsstoenad-ui/src/hooks/useInnloggetBruker.ts
@@ -6,7 +6,7 @@ import { gyldigAlder } from '../utils/alder'
 import { useBrukerContext } from '../context/bruker/BrukerContext'
 import { useNavigate } from 'react-router-dom'
 
-export const captalize = (str: string): string => {
+export const capitalize = (str: string): string => {
     const strList = str.split(' ')
     return strList
         .map((str) => {
@@ -29,8 +29,8 @@ const useInnloggetBruker = () => {
                 const alder = hentAlder(person.foedselsdato!!)
                 const kanSoeke = gyldigAlder(alder)
 
-                const fornavn = captalize(person.fornavn!!)
-                const etternavn = captalize(person.etternavn!!)
+                const fornavn = capitalize(person.fornavn!!)
+                const etternavn = capitalize(person.etternavn!!)
 
                 dispatch({
                     type: BrukerActionTypes.HENT_INNLOGGET_BRUKER,

--- a/apps/omstillingsstoenad-ui/src/utils/capitalize.test.ts
+++ b/apps/omstillingsstoenad-ui/src/utils/capitalize.test.ts
@@ -1,0 +1,61 @@
+import { capitalize, capitalizeName } from './capitalize'
+
+describe('Test av capitalize', () => {
+    it('Tester at enkelt navn i uppercase får stor forbokstav', () => {
+        const testString = 'TEST'
+        const fasitString = 'Test'
+
+        expect(capitalize(testString)).toStrictEqual(fasitString)
+    })
+
+    it('Tester at enkelt navn i lowercase får stor forbokstav', () => {
+        const testString = 'test'
+        const fasitString = 'Test'
+
+        expect(capitalize(testString)).toStrictEqual(fasitString)
+    })
+})
+
+describe('Test av capitalizeName', () => {
+    it('Tester at enkelt navn i uppercase får stor forbokstav', () => {
+        const testString = 'TEST'
+        const fasitString = 'Test'
+
+        expect(capitalizeName(testString)).toStrictEqual(fasitString)
+    })
+
+    it('Two words in uppercase is capitalized', () => {
+        const testString = 'TEST TESTESEN'
+        const fasitString = 'Test Testesen'
+
+        expect(capitalizeName(testString)).toStrictEqual(fasitString)
+    })
+
+    it('Tester at dobbeltnavn med "-" i uppercase får stor forbokstav', () => {
+        const testString = 'TEST-TESTESEN'
+        const fasitString = 'Test-Testesen'
+
+        expect(capitalizeName(testString)).toStrictEqual(fasitString)
+    })
+
+    it('Tester at enkelt navn i lowercase får stor forbokstav', () => {
+        const testString = 'test'
+        const fasitString = 'Test'
+
+        expect(capitalizeName(testString)).toStrictEqual(fasitString)
+    })
+
+    it('Tester at dobbelt navn i lowercase får stor forbokstav', () => {
+        const testString = 'test testesen'
+        const fasitString = 'Test Testesen'
+
+        expect(capitalizeName(testString)).toStrictEqual(fasitString)
+    })
+
+    it('Tester at dobbeltnavn med "-" i lowercase får stor forbokstav', () => {
+        const testString = 'test-testesen'
+        const fasitString = 'Test-Testesen'
+
+        expect(capitalizeName(testString)).toStrictEqual(fasitString)
+    })
+})

--- a/apps/omstillingsstoenad-ui/src/utils/capitalize.ts
+++ b/apps/omstillingsstoenad-ui/src/utils/capitalize.ts
@@ -1,0 +1,13 @@
+export const capitalize = (str: string): string => {
+    return str.charAt(0).toUpperCase() + str.toLowerCase().slice(1)
+}
+
+export const capitalizeName = (name: string, delim: string = ' '): string => {
+    return name
+        .split(delim)
+        .map((str) => {
+            if (str.includes('-')) return capitalizeName(str, '-')
+            return capitalize(str)
+        })
+        .join(delim)
+}


### PR DESCRIPTION
Navn er nå capitalized istedenfor uppercase

Enkelt navn
![Skjermbilde 2024-02-14 kl  11 55 16](https://github.com/navikt/pensjon-etterlatte/assets/17142094/f0e6f54c-88e7-44de-b75e-9b03a35a187b)

Dobbeltnavn med -
![Skjermbilde 2024-02-14 kl  13 41 07](https://github.com/navikt/pensjon-etterlatte/assets/17142094/60d564a9-79b5-419b-ae11-2a1cfa26ff53)


