### PR TITLE
Fikser feil i logikk ved valgfri orgnr

### DIFF
--- a/apps/omstillingsstoenad-ui/src/components/soknad/5-mer-om-situasjonen-din/fragmenter/EtablererVirksomhet.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/soknad/5-mer-om-situasjonen-din/fragmenter/EtablererVirksomhet.tsx
@@ -39,7 +39,7 @@ const EtablererVirksomhet = () => {
                     maxLength={9}
                     minLength={9}
                     htmlSize={Bredde.S}
-                    valgfri={!!!manglerOrgnr?.length}
+                    valgfri={!!manglerOrgnr?.length}
                 />
             </SkjemaElement>
 


### PR DESCRIPTION
Feltet er valgfritt når checkbox er krysset av
![Skjermbilde 2024-02-28 kl  08 09 13](https://github.com/navikt/pensjon-etterlatte/assets/17142094/15b56082-ed64-4959-bd88-0b335ca67422)

Feltet er ikke valgfritt når checkbox ikke er krysset av
![Skjermbilde 2024-02-28 kl  08 09 06](https://github.com/navikt/pensjon-etterlatte/assets/17142094/81203be0-ddc5-468a-9206-64618eb5d107)
