### PR TITLE
Fiksar yarn-lock-hash-mekanismne, set-output er visst ikkje støtta lenger

### DIFF
--- a/.github/workflows/.build-frontend.yaml
+++ b/.github/workflows/.build-frontend.yaml
@@ -43,7 +43,7 @@ jobs:
         id: keys
         run: |
           WORKFLOW=$(echo ${{ github.workflow }})
-          echo ::set-output name=yarn-lock-hash::$WORKFLOW-${{ hashFiles('apps/$WORKFLOW/yarn.lock') }}
+          echo "yarn-lock-hash=$WORKFLOW-${{ hashFiles('apps/$WORKFLOW/yarn.lock') }}" >> "$GITHUB_OUTPUT"
 
       # Client cache
       - name: Cache node modules (client)


### PR DESCRIPTION
Sjå feks https://github.com/navikt/pensjon-etterlatte/actions/runs/8263863962/job/22606212404

> Cache restored successfully
> Cache restored from key: etterlatte-node-server-