### PR TITLE
EY-3671: Send søker fra gjp til oms fra 1. april

### DIFF
--- a/apps/gjenlevendepensjon-ui/src/App.test.js
+++ b/apps/gjenlevendepensjon-ui/src/App.test.js
@@ -1,0 +1,48 @@
+import { act, render, screen } from '@testing-library/react'
+import App from './App'
+
+jest.mock('react-router', () => ({
+    ...jest.requireActual('react-router'),
+    useLocation: jest.fn().mockImplementation(() => {
+        return {
+            pathname: '/testroute',
+            search: '',
+            hash: '',
+            state: null,
+        }
+    }),
+}))
+
+jest.mock('react-i18next', () => ({
+    ...jest.requireActual('react-i18next'),
+    useTranslation: () => ({ t: jest.fn((key) => key) }),
+}))
+
+const mockedUsedNavigate = jest.fn()
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedUsedNavigate,
+}))
+
+beforeEach(() => {
+    act(() => {
+        render(<App />)
+    })
+})
+
+describe('Mulighet for å søke har utgått', () => {
+    beforeAll(() => {
+        jest.useFakeTimers('modern')
+        jest.setSystemTime(new Date(2024, 4, 1))
+    })
+
+    afterAll(() => {
+        jest.useRealTimers()
+    })
+
+    it('Etter 1. april så skal ikke bruker ha mulighet til å søke', async () => {
+        const tittel = await screen.findByText('Muligheten til å søke pengestøtte har utgått')
+
+        expect(tittel).toBeVisible()
+    })
+})

--- a/apps/gjenlevendepensjon-ui/src/App.tsx
+++ b/apps/gjenlevendepensjon-ui/src/App.tsx
@@ -16,6 +16,8 @@ import Admin from "./components/dev/Admin";
 import SoknadDialog from "./components/soknad/SoknadDialog";
 import SoknadKvittering from "./components/soknad/SoknadKvittering";
 import SoknadForside from "./components/soknad/SoknadForside";
+import SoeknadUgyldig from "./components/SoeknadUgyldig";
+import { isBefore } from "date-fns"
 
 const SoeknadWrapper = styled(ContentContainer)`
     div,
@@ -46,7 +48,7 @@ const SoeknadWrapper = styled(ContentContainer)`
 `
 
 const GlobalAlertWrap = styled.div`
-position: fixed;
+  position: fixed;
   bottom: 2em;
   left: 1em;
   right: 1em;
@@ -63,40 +65,49 @@ const App = () => {
 
     const lasterSoeknad = useSoeknad();
 
+    const foersteApril = new Date(2024, 3, 1)
+
     return (
         <>
             <Banner tekst={t("banner.tittel")} />
 
-            <LoaderOverlay visible={lasterSoeknad} label={"Henter søknadsinformasjon ..."} />
-            {!lasterSoeknad && <FortsettSoeknadModal />}
+            {isBefore(new Date(), foersteApril) ? (
+                <>
+                    <LoaderOverlay visible={lasterSoeknad} label={'Henter søknadsinformasjon ...'} />
+                    {!lasterSoeknad && <FortsettSoeknadModal />}
 
-            <SoeknadWrapper role="main">
-                <Routes>
-                    <Route index path={"/"} element={<SoknadForside />} />
+                    <SoeknadWrapper role="main">
+                        <Routes>
+                            <Route index path={'/'} element={<SoknadForside />} />
 
-                    <Route path={"skjema"} element={<Outlet />} >
-                        <Route path={"steg/*"} element={<SoknadDialog />} />
-                    </Route>
+                            <Route path={'skjema'} element={<Outlet />}>
+                                <Route path={'steg/*'} element={<SoknadDialog />} />
+                            </Route>
 
-                    <Route path={"/skjema/admin"} element={<Admin />} />
+                            <Route path={'/skjema/admin'} element={<Admin />} />
 
-                    <Route path={"/skjema/sendt"} element={<SoknadKvittering />} />
+                            <Route path={'/skjema/sendt'} element={<SoknadKvittering />} />
 
-                    <Route path={"/ugyldig-alder"} element={<UgyldigSoeker />} />
+                            <Route path={'/ugyldig-alder'} element={<UgyldigSoeker />} />
 
-                    <Route path={"/system-utilgjengelig"} element={<SystemUtilgjengelig />} />
+                            <Route path={'/system-utilgjengelig'} element={<SystemUtilgjengelig />} />
 
-                    <Route path={"/labs"} element={<Navigate replace to="/skjema/admin" />} />
+                            <Route path={'/labs'} element={<Navigate replace to="/skjema/admin" />} />
 
-                    <Route path={"*"} element={<SideIkkeFunnet />} />
-
-                </Routes>
-                {soknadContext?.state?.error && (
-                    <GlobalAlertWrap>
-                        <Alert variant="error">{soknadContext?.state?.error}</Alert>
-                    </GlobalAlertWrap>
-                )}
-            </SoeknadWrapper>
+                            <Route path={'*'} element={<SideIkkeFunnet />} />
+                        </Routes>
+                        {soknadContext?.state?.error && (
+                            <GlobalAlertWrap>
+                                <Alert variant="error">{soknadContext?.state?.error}</Alert>
+                            </GlobalAlertWrap>
+                        )}
+                    </SoeknadWrapper>
+                </>
+            ) : (
+                <SoeknadWrapper role="main">
+                    <SoeknadUgyldig />
+                </SoeknadWrapper>
+            )}
         </>
     );
 };

--- a/apps/gjenlevendepensjon-ui/src/components/SoeknadUgyldig.tsx
+++ b/apps/gjenlevendepensjon-ui/src/components/SoeknadUgyldig.tsx
@@ -17,7 +17,7 @@ const SoeknadUgyldig = () => {
                 </SkjemaElement>
                 <SkjemaElement>
                     <Button as={'a'} href={'/omstillingsstonad/soknad'}>
-                        Gå til søknad om omstillingsstønad
+                        Søk om omstillingsstønad
                     </Button>
                 </SkjemaElement>
             </SkjemaGruppe>

--- a/apps/gjenlevendepensjon-ui/src/components/SoeknadUgyldig.tsx
+++ b/apps/gjenlevendepensjon-ui/src/components/SoeknadUgyldig.tsx
@@ -1,0 +1,41 @@
+import { SkjemaElement } from './felles/SkjemaElement'
+import { BodyShort, Button, Heading, Link, Panel } from '@navikt/ds-react'
+import { SkjemaGruppe } from './felles/SkjemaGruppe'
+
+const SoeknadUgyldig = () => {
+    return (
+        <Panel>
+            <SkjemaGruppe>
+                <Heading size={'large'}>
+                    Muligheten til å søke pengestøtte har utgått
+                </Heading>
+                <SkjemaElement>
+                    <BodyShort>
+                        Fra 1. april 2024 er det ikke lenger mulig å søke om gjenlevendepensjon eller
+                        overgangsstønad. Du kan derimot søke om omstillingsstønad.
+                    </BodyShort>
+                </SkjemaElement>
+                <SkjemaElement>
+                    <Button as={'a'} href={'/omstillingsstonad/soknad'}>
+                        Gå til søknad om omstillingsstønad
+                    </Button>
+                </SkjemaElement>
+            </SkjemaGruppe>
+
+            <SkjemaGruppe>
+                <Heading size={'large'} level={"2"}>
+                    It is no longer possible to apply for financial support
+                </Heading>
+                <SkjemaElement>
+                    <BodyShort>
+                        From April 1, 2024, it is no longer possible to apply for survivor’s pension or
+                        transitional benefit. However, you can&nbsp;
+                        <Link href={'/omstillingsstonad/soknad'}>apply for for adjustment allowance.</Link>
+                    </BodyShort>
+                </SkjemaElement>
+            </SkjemaGruppe>
+        </Panel>
+    )
+}
+
+export default SoeknadUgyldig


### PR DESCRIPTION
Gi søker beskjed om at GJP ikke lenger er mulig å søke på etter 1. april 2024

![Skjermbilde 2024-03-13 kl  14 30 08](https://github.com/navikt/pensjon-etterlatte/assets/17142094/5f9b2593-bcb7-4456-a0fd-b522cf099ad2)
