### PR TITLE
EY-3720: Legg til utbetalingsinformasjon for utenlandsk konto på barnepensjon

### DIFF
--- a/apps/omstillingsstoenad-ui/src/api/mapper/soeknadMapper.ts
+++ b/apps/omstillingsstoenad-ui/src/api/mapper/soeknadMapper.ts
@@ -46,7 +46,7 @@ export const mapTilOmstillingsstoenadSoeknad = (
                 svar: bruker.foedselsnummer!!,
             },
         },
-        utbetalingsInformasjon: hentUtbetalingsInformasjonSoeker(t, soeknad.omDeg),
+        utbetalingsInformasjon: hentUtbetalingsInformasjonSoeker(t, soeknad.omDeg.utbetalingsInformasjon!!),
         soeker: mapGjenlevende(t, soeknad, bruker),
         avdoed: mapAvdoed(t, soeknad),
         barn,

--- a/apps/omstillingsstoenad-ui/src/components/soknad/1-omdeg/utenlandskBankInfo/UtenlandskBankInfo.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/soknad/1-omdeg/utenlandskBankInfo/UtenlandskBankInfo.tsx
@@ -10,9 +10,10 @@ const HelpTextLabel = styled.div`
     display: flex;
 `
 
-const UtenlandskBankInfo = () => {
+const UtenlandskBankInfo = ({ kontonummerTilhoererBarn = false }: { kontonummerTilhoererBarn?: boolean }) => {
     const { t } = useTranslation()
 
+    const prefix = kontonummerTilhoererBarn ? 'barnepensjon.' : ''
     return (
         <>
             <SkjemaElement>
@@ -21,20 +22,20 @@ const UtenlandskBankInfo = () => {
 
             <SkjemaElement>
                 <RHFInput
-                    name={'utbetalingsInformasjon.utenlandskBankNavn'}
+                    name={`${prefix}utbetalingsInformasjon.utenlandskBankNavn`}
                     label={t('omDeg.utbetalingsInformasjon.utenlandskBankNavn')}
                 />
             </SkjemaElement>
 
             <SkjemaElement>
                 <RHFInput
-                    name={'utbetalingsInformasjon.utenlandskBankAdresse'}
+                    name={`${prefix}utbetalingsInformasjon.utenlandskBankAdresse`}
                     label={t('omDeg.utbetalingsInformasjon.utenlandskBankAdresse')}
                 />
             </SkjemaElement>
             <SkjemaElement>
                 <RHFIbanInput
-                    name={'utbetalingsInformasjon.iban'}
+                    name={`${prefix}utbetalingsInformasjon.iban`}
                     htmlSize={Bredde.M}
                     label={
                         <HelpTextLabel>
@@ -46,7 +47,7 @@ const UtenlandskBankInfo = () => {
             </SkjemaElement>
             <SkjemaElement>
                 <RHFBicInput
-                    name={'utbetalingsInformasjon.swift'}
+                    name={`${prefix}utbetalingsInformasjon.swift`}
                     htmlSize={Bredde.S}
                     label={
                         <HelpTextLabel>

--- a/apps/omstillingsstoenad-ui/src/components/soknad/7-barnepensjon/__snapshots__/OpplysningerOmBarn.test.js.snap
+++ b/apps/omstillingsstoenad-ui/src/components/soknad/7-barnepensjon/__snapshots__/OpplysningerOmBarn.test.js.snap
@@ -117,7 +117,7 @@ exports[`Opplysninger om barn Snapshot 1`] = `
       class="sc-beySPh hBKmDL"
     >
       <div
-        class="sc-khjJXk kQjEWH"
+        class="sc-fLseNd eibpgF"
       >
         <div
           class="sc-gLLuof LUiTB"
@@ -134,7 +134,7 @@ exports[`Opplysninger om barn Snapshot 1`] = `
             class="sc-jTQCzO eqaiVI"
           >
             <div
-              class="sc-fLseNd bHrFHw"
+              class="sc-bBkKde ixPkOT"
             >
               <button
                 class="navds-button navds-button--primary navds-button--medium"

--- a/apps/omstillingsstoenad-ui/src/components/soknad/8-oppsummering/fragmenter/OppsummeringBarnepensjon.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/soknad/8-oppsummering/fragmenter/OppsummeringBarnepensjon.tsx
@@ -9,6 +9,7 @@ import { TekstGruppe, TekstGruppeJaNeiVetIkke } from './TekstGruppe'
 import { IValg } from '../../../../typer/Spoersmaal'
 import { SkjemaElement } from '../../../felles/SkjemaElement'
 import { Panel } from '../../../felles/Panel'
+import UtbetalingsInformasjonOppsummering from './UtbetalingsInformasjonOppsummering'
 
 interface Props {
     opplysningerOmBarn: IOmBarn
@@ -99,9 +100,8 @@ export const OppsummeringBarnepensjon = memo(({ opplysningerOmBarn, senderSoekna
 
                         {barnet.barnepensjon?.kontonummer?.svar === IValg.NEI && (
                             <Panel>
-                                <TekstGruppe
-                                    tittel={t('omBarn.barnepensjon.kontonummer.kontonummer')}
-                                    innhold={barnet.barnepensjon.kontonummer.kontonummer}
+                                <UtbetalingsInformasjonOppsummering
+                                    utbetalingsInformasjon={barnet.barnepensjon.utbetalingsInformasjon!!}
                                 />
                             </Panel>
                         )}

--- a/apps/omstillingsstoenad-ui/src/locales/en.ts
+++ b/apps/omstillingsstoenad-ui/src/locales/en.ts
@@ -1122,6 +1122,19 @@ export default {
     'feil.barnepensjon.kontonummer.kontonummer.required':
         'Norwegian bank account number is a required field (11 digits)',
     'feil.barnepensjon.kontonummer.kontonummer.pattern': 'Account number not valid. It must have 11 digits.',
+    'feil.barnepensjon.utbetalingsInformasjon.bankkontoType.required':
+        'You must choose whether you want the money to be paid into a Norwegian bank account or a foreign bank account',
+    'feil.barnepensjon.utbetalingsInformasjon.kontonummer.required':
+        'Norwegian bank account number is a required field (11 digits)',
+    'feil.barnepensjon.utbetalingsInformasjon.kontonummer.pattern': 'Account number not valid. It must have 11 digits.',
+    'feil.barnepensjon.utbetalingsInformasjon.utenlandskBankNavn.required':
+        'The name of the foreign bank is a required field',
+    'feil.barnepensjon.utbetalingsInformasjon.utenlandskBankAdresse.required':
+        'The address of the foreign bank is a required field',
+    'feil.barnepensjon.utbetalingsInformasjon.iban.required': 'IBAN number is a required field',
+    'feil.barnepensjon.utbetalingsInformasjon.iban.validate': 'Invalid IBAN',
+    'feil.barnepensjon.utbetalingsInformasjon.swift.required': 'The bank’s SWIFT code or BIC is a required field',
+    'feil.barnepensjon.utbetalingsInformasjon.swift.validate': 'Invalid SWIFT code or BIC',
     'feil.barnepensjon.forskuddstrekk.svar.required':
         'State whether you want tax to be deducted from the children’s pension',
     'feil.barnepensjon.forskuddstrekk.trekkprosent.required': 'Enter a valid percentage',

--- a/apps/omstillingsstoenad-ui/src/locales/nb.ts
+++ b/apps/omstillingsstoenad-ui/src/locales/nb.ts
@@ -1073,6 +1073,18 @@ export default {
         'Oppgi om du ønsker et annet kontonummer for utbetaling av barnepensjon',
     'feil.barnepensjon.kontonummer.kontonummer.required': 'Norsk kontonummer må fylles ut (11 siffer)',
     'feil.barnepensjon.kontonummer.kontonummer.pattern': 'Kontonummer ikke gyldig. Må bestå av 11 siffer.',
+    'feil.barnepensjon.utbetalingsInformasjon.bankkontoType.required':
+        'Du må velge mellom norsk eller utenlandsk bankkonto for utbetaling',
+    'feil.barnepensjon.utbetalingsInformasjon.kontonummer.required': 'Norsk kontonummer må fylles ut (11 siffer)',
+    'feil.barnepensjon.utbetalingsInformasjon.kontonummer.pattern': 'Kontonummer ikke gyldig. Må bestå av 11 siffer.',
+    'feil.barnepensjon.utbetalingsInformasjon.utenlandskBankNavn.required':
+        'Navnet på den utenlandske banken må fylles ut',
+    'feil.barnepensjon.utbetalingsInformasjon.utenlandskBankAdresse.required':
+        'Adressen til den utenlandske banken må fylles ut',
+    'feil.barnepensjon.utbetalingsInformasjon.iban.required': 'IBAN-nummer må fylles ut',
+    'feil.barnepensjon.utbetalingsInformasjon.iban.validate': 'Ugyldig IBAN-nummer',
+    'feil.barnepensjon.utbetalingsInformasjon.swift.required': 'Bankens S.W.I.F.T (BIC) adresse må fylles ut',
+    'feil.barnepensjon.utbetalingsInformasjon.swift.validate': 'Ugyldig SWIFT/BIC kode',
     'feil.barnepensjon.forskuddstrekk.svar.required': 'Oppgi om du ønsker skattetrekk for barnepensjonen',
     'feil.barnepensjon.forskuddstrekk.trekkprosent.required': 'Oppgi en gyldig prosent',
     'feil.dagligOmsorg.required': 'Oppgi om du har daglig omsorg for barnet',

--- a/apps/omstillingsstoenad-ui/src/locales/nn.ts
+++ b/apps/omstillingsstoenad-ui/src/locales/nn.ts
@@ -1075,6 +1075,18 @@ export default {
         'Oppgi om du ønsker eit anna kontonummer for utbetaling av barnepensjon',
     'feil.barnepensjon.kontonummer.kontonummer.required': 'Norsk kontonummer må fyllast ut (11 siffer)',
     'feil.barnepensjon.kontonummer.kontonummer.pattern': 'Kontonummer ikkje gyldig. Må ha 11 siffer.',
+    'feil.barnepensjon.utbetalingsInformasjon.bankkontoType.required':
+        'Du må velje mellom norsk eller utanlandsk bankkonto for utbetaling',
+    'feil.barnepensjon.utbetalingsInformasjon.kontonummer.required': 'Norsk kontonummer må fyllast ut (11 siffer)',
+    'feil.barnepensjon.utbetalingsInformasjon.kontonummer.pattern': 'Kontonummeret ikkje gyldig. Må ha 11 siffer.',
+    'feil.barnepensjon.utbetalingsInformasjon.utenlandskBankNavn.required':
+        'Namnet på den utanlandske banken må fyllast ut',
+    'feil.barnepensjon.utbetalingsInformasjon.utenlandskBankAdresse.required':
+        'Adressa til den utanlandske banken må fyllast ut',
+    'feil.barnepensjon.utbetalingsInformasjon.iban.required': 'IBAN-nummer må fyllast ut',
+    'feil.barnepensjon.utbetalingsInformasjon.iban.validate': 'Ugyldig IBAN-nummer',
+    'feil.barnepensjon.utbetalingsInformasjon.swift.required': 'Bankens S.W.I.F.T (BIC) adresse må fyllast ut',
+    'feil.barnepensjon.utbetalingsInformasjon.swift.validate': 'Ugyldig SWIFT/BIC kode',
     'feil.barnepensjon.forskuddstrekk.svar.required': 'Oppgi om du ønsker skattetrekk for barnepensjonen',
     'feil.barnepensjon.forskuddstrekk.trekkprosent.required': 'Oppgi ein gyldig prosent',
     'feil.dagligOmsorg.required': 'Oppgi om du har dagleg omsorg for barnet',

--- a/apps/omstillingsstoenad-ui/src/typer/person.ts
+++ b/apps/omstillingsstoenad-ui/src/typer/person.ts
@@ -70,8 +70,8 @@ export interface IBarn {
         soeker?: IValg.JA | undefined
         kontonummer?: {
             svar?: IValg
-            kontonummer?: string
         }
+        utbetalingsInformasjon?: IUtbetalingsInformasjon
         forskuddstrekk?: {
             svar?: IValg
             trekkprosent?: string


### PR DESCRIPTION
- Ikke vis skattetrekk hvis utenlandsk konto er valgt

Legge til norsk kontonummer på barnet -> La bruker velge om de ønsker skattetrekk
<img width="503" alt="Skjermbilde 2024-03-21 kl  08 57 05" src="https://github.com/navikt/pensjon-etterlatte/assets/17142094/b7be2e7e-f786-4289-be18-ae6f3bb9f7fa">

Legge til utenlandsk kontonummer på barnet -> Ikke la bruker velge ønske skattetrekk
<img width="504" alt="Skjermbilde 2024-03-21 kl  08 57 28" src="https://github.com/navikt/pensjon-etterlatte/assets/17142094/7bcaed0c-06e4-4aa9-a42a-677cdd889a15">

Hvis gjenlevende har norsk kontonummer -> La bruker velge om de ønsker skattetrekk
<img width="523" alt="Skjermbilde 2024-03-21 kl  08 57 44" src="https://github.com/navikt/pensjon-etterlatte/assets/17142094/abd382a3-c884-487a-80a7-7875eef5afd2">

Hvis gjenlevende har utenlandsk kontonummer -> Ikke la bruker velge ønske skattetrekk
<img width="518" alt="Skjermbilde 2024-03-21 kl  08 58 21" src="https://github.com/navikt/pensjon-etterlatte/assets/17142094/016d0c7c-7cad-49b6-93a0-411009ee8bda">


