### PR TITLE
Hotfix: Ikke kaste feil ved 409 (duplikat journalpost)

### DIFF
--- a/apps/journalfoer-soeknad/src/main/kotlin/dokarkiv/DokarkivKlient.kt
+++ b/apps/journalfoer-soeknad/src/main/kotlin/dokarkiv/DokarkivKlient.kt
@@ -42,10 +42,8 @@ class DokarkivKlient(private val client: HttpClient, private val baseUrl: String
 
             if (response.status.isSuccess()) response.body()
             else if (response.status == HttpStatusCode.Conflict) {
-                throw ResponseException(
-                    response,
-                    "Duplikat journalpost - søknaden med tittel '${request.tittel}' har allerede blitt journalført"
-                )
+                response.body<DokarkivResponse>()
+                    .also { logger.error("Duplikat journalpost (journalpostId=${it.journalpostId})") }
             } else {
                 val errorResponse = response.body<DokarkivErrorResponse>()
                     .also { logger.error("${it.message}: ${response.status} ${it.error}") }

--- a/apps/journalfoer-soeknad/src/test/kotlin/dokarkiv/DokarkivKlientTest.kt
+++ b/apps/journalfoer-soeknad/src/test/kotlin/dokarkiv/DokarkivKlientTest.kt
@@ -70,13 +70,11 @@ internal class DokarkivKlientTest {
 
         val klient = opprettKlient(duplikatResponse, HttpStatusCode.Conflict)
 
-        try {
-            runBlocking { klient.journalfoerDok(dummyRequest(), false) }
+        val response = runBlocking { klient.journalfoerDok(dummyRequest(), false) }
 
-            fail("Skal kaste feil ved HttpStatusCode.Conflict (409)")
-        } catch (re: ResponseException) {
-            assertEquals(HttpStatusCode.Conflict, re.response.status)
-        }
+        assertEquals("467010363", response.journalpostId)
+        assertEquals(true, response.journalpostferdigstilt)
+        assertEquals(1, response.dokumenter.size)
     }
 
     @Test


### PR DESCRIPTION
Dette skjer som oftest fordi første kall mot dokarkiv ikke har gitt respons. I siste tilfelle fikk første kall timeout, men journalposten ble lagret. Når riveren forsøker på nytt kastes det feil. Dette er litt unødvendig. 

Dokarkiv returnerer samme respons på 200 og 409, så det ryddigste er å bare logge warning og journalpostId på dokumentet det gjelder. 

https://dokarkiv.dev.intern.nav.no/swagger-ui/index.html#/journalpostapi/opprettJournalpost
