### PR TITLE
Rettar syntaks i braces-versjonslåsinga

### DIFF
--- a/apps/barnepensjon-ui/package.json
+++ b/apps/barnepensjon-ui/package.json
@@ -88,6 +88,6 @@
     "bracketSpacing": true
   },
   "resolutions": {
-    "**/braces": "^3.0.3"
+    "**/braces": "3.0.3"
   }
 }

--- a/apps/barnepensjon-ui/package.json
+++ b/apps/barnepensjon-ui/package.json
@@ -88,6 +88,6 @@
     "bracketSpacing": true
   },
   "resolutions": {
-    "braces": "3.0.3"
+    "**/braces": "^3.0.3"
   }
 }

--- a/apps/etterlatte-node-server/package.json
+++ b/apps/etterlatte-node-server/package.json
@@ -50,6 +50,6 @@
     "singleQuote": true
   },
   "resolutions": {
-    "**/braces": "^3.0.3"
+    "**/braces": "3.0.3"
   }
 }

--- a/apps/etterlatte-node-server/package.json
+++ b/apps/etterlatte-node-server/package.json
@@ -48,5 +48,8 @@
     "tabWidth": 4,
     "semi": false,
     "singleQuote": true
+  },
+  "resolutions": {
+    "**/braces": "^3.0.3"
   }
 }

--- a/apps/omstillingsstoenad-ui/package.json
+++ b/apps/omstillingsstoenad-ui/package.json
@@ -96,6 +96,6 @@
     ]
   },
   "resolutions": {
-    "**/braces": "^3.0.3"
+    "**/braces": "3.0.3"
   }
 }

--- a/apps/omstillingsstoenad-ui/package.json
+++ b/apps/omstillingsstoenad-ui/package.json
@@ -96,6 +96,6 @@
     ]
   },
   "resolutions": {
-    "braces": "3.0.3"
+    "**/braces": "^3.0.3"
   }
 }


### PR DESCRIPTION
Verifisert i dependencytrack at braces 3.0.2, som ga åtvaringar tidlegare, no ikkje gjer det: https://salsa.nav.cloud.nais.io/projects/947307e1-31d9-4282-a3d2-4900678e5478/findings