### PR TITLE
Tar med husky og vite-tsconfig-paths i dependabot-grupperinga, ingen …

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,6 +51,7 @@ updates:
           - "eslint-plugin*"
           - "prettier"
           - "axe-core"
+          - "husky"
           - "cypress"
           - "cypress-axe"
           - "@testing-library/*"
@@ -79,6 +80,7 @@ updates:
           - "@types/amplitude-js"
           - "amplitude-js"
           - "vite"
+          - "vite-tsconfig-paths"
       node-server:
         patterns:
           - "@navikt/nav-dekoratoren-moduler"


### PR DESCRIPTION
…grunn til at dei skal krevje å vera sine eigne PR-ar