### PR TITLE
Fjern ekstern fra oms i dev [Avvent merge til oms er fikset for mobil]

### DIFF
--- a/apps/omstillingsstoenad-ui/.nais/dev.yaml
+++ b/apps/omstillingsstoenad-ui/.nais/dev.yaml
@@ -14,7 +14,6 @@ spec:
     cpuThresholdPercentage: 90
   ingresses:
     - https://etterlatte.intern.dev.nav.no/omstillingsstonad/soknad
-    - https://etterlatte.ekstern.dev.nav.no/omstillingsstonad/soknad
   liveness:
     path: /omstillingsstonad/soknad/isAlive
     initialDelay: 10


### PR DESCRIPTION
Skal fjernes når fokus på å fikse oms på mobil er over. Lager PR for å ikke glemme det.