### PR TITLE
EY-4156: Tydligere visning av hva hvilke felter som slettes

### DIFF
--- a/apps/omstillingsstoenad-ui/src/components/felles/Panel.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/felles/Panel.tsx
@@ -1,23 +1,30 @@
 import { Box } from '@navikt/ds-react'
 import { ComponentProps, ReactNode } from 'react'
-import { ResponsiveProp, SpacingScale } from '@navikt/ds-react/src/layout/utilities/types'
-interface PanelProps extends ComponentProps<"div">{
+import { ResponsiveProp, SpacingScale, SpaceDelimitedAttribute } from '@navikt/ds-react/src/layout/utilities/types'
+
+interface PanelProps extends ComponentProps<'div'> {
     children: ReactNode
-    border?: boolean
+    borderRadius?: boolean
+    borderColor?: 'border-default' | 'border-info'
+    borderWidth?: SpaceDelimitedAttribute<'0' | '1' | '2' | '3' | '4' | '5'>
     padding?: ResponsiveProp<SpacingScale>
+    background?: 'surface-default' | 'surface-selected'
 }
 export const Panel = ({
     children,
-    border = false,
+    borderRadius = false,
     padding = '4',
+    background = 'surface-default',
+    borderWidth = '0',
+    borderColor,
     ...props
 }: PanelProps) => (
     <Box
-        background={'surface-default'}
+        background={background}
         padding={padding}
-        borderColor={border ? 'border-default' : undefined}
-        borderWidth={border ? '1' : '0'}
-        borderRadius={border ? 'small' : undefined}
+        borderColor={borderColor}
+        borderWidth={borderWidth}
+        borderRadius={borderRadius ? 'small' : undefined}
         {...props}
     >
         {children}

--- a/apps/omstillingsstoenad-ui/src/components/felles/Panel.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/felles/Panel.tsx
@@ -1,30 +1,19 @@
 import { Box } from '@navikt/ds-react'
 import { ComponentProps, ReactNode } from 'react'
-import { ResponsiveProp, SpacingScale, SpaceDelimitedAttribute } from '@navikt/ds-react/src/layout/utilities/types'
+import { ResponsiveProp, SpacingScale } from '@navikt/ds-react/src/layout/utilities/types'
 
 interface PanelProps extends ComponentProps<'div'> {
     children: ReactNode
-    borderRadius?: boolean
-    borderColor?: 'border-default' | 'border-info'
-    borderWidth?: SpaceDelimitedAttribute<'0' | '1' | '2' | '3' | '4' | '5'>
+    border?: boolean
     padding?: ResponsiveProp<SpacingScale>
-    background?: 'surface-default' | 'surface-selected'
 }
-export const Panel = ({
-    children,
-    borderRadius = false,
-    padding = '4',
-    background = 'surface-default',
-    borderWidth = '0',
-    borderColor,
-    ...props
-}: PanelProps) => (
+export const Panel = ({ children, border = false, padding = '4', ...props }: PanelProps) => (
     <Box
-        background={background}
+        background={'surface-default'}
         padding={padding}
-        borderColor={borderColor}
-        borderWidth={borderWidth}
-        borderRadius={borderRadius ? 'small' : undefined}
+        borderColor={border ? 'border-default' : undefined}
+        borderWidth={border ? '1' : '0'}
+        borderRadius={border ? 'small' : undefined}
         {...props}
     >
         {children}

--- a/apps/omstillingsstoenad-ui/src/components/soknad/2-omdegogavdoed/nySivilstatus/SamboerSkjema.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/soknad/2-omdegogavdoed/nySivilstatus/SamboerSkjema.tsx
@@ -12,7 +12,7 @@ const SamboerSkjema = () => {
 
     return (
         <SkjemaElement>
-            <Panel border>
+            <Panel borderColor={'border-info'} borderWidth={'0 0 0 4'} background={'surface-selected'}>
                 <SkjemaElement>
                     <Heading size={'small'}>{t('situasjonenDin.nySivilstatus.samboerskap.samboer.tittel')}</Heading>
                 </SkjemaElement>

--- a/apps/omstillingsstoenad-ui/src/components/soknad/2-omdegogavdoed/nySivilstatus/SamboerSkjema.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/soknad/2-omdegogavdoed/nySivilstatus/SamboerSkjema.tsx
@@ -2,17 +2,16 @@ import { useTranslation } from 'react-i18next'
 import { RHFFoedselsnummerInput, RHFInput } from '../../../felles/rhf/RHFInput'
 import { RHFSpoersmaalRadio } from '../../../felles/rhf/RHFRadio'
 import { fnr } from '@navikt/fnrvalidator'
-import { Heading, HGrid } from '@navikt/ds-react'
+import { Box, Heading, HGrid } from '@navikt/ds-react'
 import { SkjemaElement } from '../../../felles/SkjemaElement'
 import Bredde from '../../../../typer/bredde'
-import { Panel } from '../../../felles/Panel'
 
 const SamboerSkjema = () => {
     const { t } = useTranslation()
 
     return (
         <SkjemaElement>
-            <Panel borderColor={'border-info'} borderWidth={'0 0 0 4'} background={'surface-selected'}>
+            <Box padding="4" borderColor={'border-info'} borderWidth={'0 0 0 4'} background={'surface-selected'}>
                 <SkjemaElement>
                     <Heading size={'small'}>{t('situasjonenDin.nySivilstatus.samboerskap.samboer.tittel')}</Heading>
                 </SkjemaElement>
@@ -45,7 +44,7 @@ const SamboerSkjema = () => {
                         legend={t('situasjonenDin.nySivilstatus.samboerskap.hattBarnEllerVaertGift')}
                     />
                 </SkjemaElement>
-            </Panel>
+            </Box>
         </SkjemaElement>
     )
 }

--- a/apps/omstillingsstoenad-ui/src/components/soknad/3-avdod/fragmenter/BoddEllerArbeidetUtland.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/soknad/3-avdod/fragmenter/BoddEllerArbeidetUtland.tsx
@@ -13,7 +13,6 @@ import { RHFSelect } from '../../../felles/rhf/RHFSelect'
 import useCountries from '../../../../hooks/useCountries'
 import { SkjemaElement } from '../../../felles/SkjemaElement'
 import { SkjemaGruppe } from '../../../felles/SkjemaGruppe'
-import { Panel } from '../../../felles/Panel'
 import { useValutaer } from '../../../../hooks/useValutaer'
 import { RHFCombobox } from '~components/felles/rhf/RHFCombobox'
 
@@ -58,11 +57,12 @@ const BoddEllerArbeidetUtland = ({ datoForDoedsfallet }: Props) => {
             {boddEllerArbeidetUtland === IValg.JA && (
                 <VStack gap="4">
                     {fields.map((field: FieldArrayWithId, index: number) => (
-                        <Panel
+                        <Box
                             borderColor={'border-info'}
                             borderWidth={'0 0 0 4'}
                             key={field.id}
                             background={'surface-selected'}
+                            padding="4"
                         >
                             <Box maxWidth="14rem">
                                 <SkjemaElement>
@@ -163,7 +163,7 @@ const BoddEllerArbeidetUtland = ({ datoForDoedsfallet }: Props) => {
                                     </Button>
                                 </div>
                             )}
-                        </Panel>
+                        </Box>
                     ))}
 
                     <div>

--- a/apps/omstillingsstoenad-ui/src/components/soknad/3-avdod/fragmenter/BoddEllerArbeidetUtland.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/soknad/3-avdod/fragmenter/BoddEllerArbeidetUtland.tsx
@@ -8,31 +8,14 @@ import React, { useEffect } from 'react'
 import { RHFCheckboksGruppe } from '../../../felles/rhf/RHFCheckboksPanelGruppe'
 import { useTranslation } from 'react-i18next'
 import { DeleteFilled } from '@navikt/ds-icons'
-import { BodyLong, BodyShort, Box, Button, Heading, HGrid, Label } from '@navikt/ds-react'
+import { BodyLong, BodyShort, Box, Button, Heading, HGrid, Label, VStack } from '@navikt/ds-react'
 import { RHFSelect } from '../../../felles/rhf/RHFSelect'
 import useCountries from '../../../../hooks/useCountries'
 import { SkjemaElement } from '../../../felles/SkjemaElement'
 import { SkjemaGruppe } from '../../../felles/SkjemaGruppe'
-import styled from 'styled-components'
 import { Panel } from '../../../felles/Panel'
 import { useValutaer } from '../../../../hooks/useValutaer'
 import { RHFCombobox } from '~components/felles/rhf/RHFCombobox'
-
-const Rad = styled.div`
-    width: 100%;
-    display: flex;
-    flex-direction: row;
-    column-gap: 1rem;
-    column-gap: 1rem;
-`
-const ArbeidIUtlandPanel = styled(Panel)`
-    @media screen and (max-width: 450px) {
-        padding-left: 0;
-        padding-right: 0;
-        border-left: none;
-        border-right: none;
-    }
-`
 
 interface Props {
     datoForDoedsfallet?: Date
@@ -73,9 +56,14 @@ const BoddEllerArbeidetUtland = ({ datoForDoedsfallet }: Props) => {
             </SkjemaElement>
 
             {boddEllerArbeidetUtland === IValg.JA && (
-                <>
+                <VStack gap="4">
                     {fields.map((field: FieldArrayWithId, index: number) => (
-                        <ArbeidIUtlandPanel border key={field.id} className={'luft-under'}>
+                        <Panel
+                            borderColor={'border-info'}
+                            borderWidth={'0 0 0 4'}
+                            key={field.id}
+                            background={'surface-selected'}
+                        >
                             <Box maxWidth="14rem">
                                 <SkjemaElement>
                                     <RHFCombobox
@@ -106,24 +94,20 @@ const BoddEllerArbeidetUtland = ({ datoForDoedsfallet }: Props) => {
                             </SkjemaElement>
 
                             <SkjemaElement>
-                                <Rad>
-                                    <div className={'kol'}>
-                                        <Datovelger
-                                            name={`boddEllerJobbetUtland.oppholdUtland[${index}].fraDato` as const}
-                                            label={t('omDenAvdoede.boddEllerJobbetUtland.oppholdUtland.fraDato')}
-                                            maxDate={datoForDoedsfallet || new Date()}
-                                            valgfri
-                                        />
-                                    </div>
-                                    <div className={'kol'}>
-                                        <Datovelger
-                                            name={`boddEllerJobbetUtland.oppholdUtland[${index}].tilDato` as const}
-                                            label={t('omDenAvdoede.boddEllerJobbetUtland.oppholdUtland.tilDato')}
-                                            maxDate={datoForDoedsfallet || new Date()}
-                                            valgfri
-                                        />
-                                    </div>
-                                </Rad>
+                                <VStack gap="4">
+                                    <Datovelger
+                                        name={`boddEllerJobbetUtland.oppholdUtland[${index}].fraDato` as const}
+                                        label={t('omDenAvdoede.boddEllerJobbetUtland.oppholdUtland.fraDato')}
+                                        maxDate={datoForDoedsfallet || new Date()}
+                                        valgfri
+                                    />
+                                    <Datovelger
+                                        name={`boddEllerJobbetUtland.oppholdUtland[${index}].tilDato` as const}
+                                        label={t('omDenAvdoede.boddEllerJobbetUtland.oppholdUtland.tilDato')}
+                                        maxDate={datoForDoedsfallet || new Date()}
+                                        valgfri
+                                    />
+                                </VStack>
                             </SkjemaElement>
 
                             <RHFSpoersmaalRadio
@@ -168,19 +152,26 @@ const BoddEllerArbeidetUtland = ({ datoForDoedsfallet }: Props) => {
                             </SkjemaElement>
 
                             {fields.length > 1 && (
-                                <div style={{ textAlign: 'right' }}>
-                                    <Button variant={'secondary'} type={'button'} onClick={() => remove(index)}>
-                                        <DeleteFilled /> &nbsp;{t('knapp.fjern')}
+                                <div>
+                                    <Button
+                                        variant={'secondary'}
+                                        type={'button'}
+                                        onClick={() => remove(index)}
+                                        icon={<DeleteFilled />}
+                                    >
+                                        {t('knapp.fjern')}
                                     </Button>
                                 </div>
                             )}
-                        </ArbeidIUtlandPanel>
+                        </Panel>
                     ))}
 
-                    <Button variant={'secondary'} type={'button'} onClick={() => append({}, { shouldFocus: true })}>
-                        + {t('knapp.leggTilLand')}
-                    </Button>
-                </>
+                    <div>
+                        <Button variant={'secondary'} type={'button'} onClick={() => append({}, { shouldFocus: true })}>
+                            + {t('knapp.leggTilLand')}
+                        </Button>
+                    </div>
+                </VStack>
             )}
         </SkjemaGruppe>
     )

--- a/apps/omstillingsstoenad-ui/src/components/soknad/5-mer-om-situasjonen-din/__snapshots__/MerOmSituasjonenDin.test.jsx.snap
+++ b/apps/omstillingsstoenad-ui/src/components/soknad/5-mer-om-situasjonen-din/__snapshots__/MerOmSituasjonenDin.test.jsx.snap
@@ -477,1698 +477,1710 @@ exports[`Mer om situasjonen din > Skal rendre selvstendig 1`] = `
           </h1>
         </div>
         <div
-          class="sc-cHqXqK jvHoMc"
-        >
-          <div>
-            <div
-              class="navds-form-field navds-form-field--medium"
-            >
-              <label
-                class="navds-form-field__label navds-label"
-                for="arbeidsforhold[0].arbeidsgiver"
-              >
-                merOmSituasjonenDin.arbeidsforhold.arbeidsgiver
-              </label>
-              <input
-                class="navds-text-field__input navds-body-short navds-body-short--medium"
-                id="arbeidsforhold[0].arbeidsgiver"
-                size="35"
-                type="text"
-                value="Potetskreller AS"
-              />
-              <div
-                aria-live="polite"
-                aria-relevant="additions removals"
-                class="navds-form-field__error"
-                id="textField-error-r3m"
-              />
-            </div>
-          </div>
-        </div>
-        <div
-          class="sc-cHqXqK jvHoMc"
+          class="navds-stack navds-vstack navds-stack-gap navds-stack-direction"
+          style="--__ac-stack-gap-xs: var(--a-spacing-4); --__ac-stack-direction-xs: column;"
         >
           <div
-            id="arbeidsforhold[0].ansettelsesforhold"
-          >
-            <fieldset
-              class="navds-radio-group navds-radio-group--medium navds-fieldset navds-fieldset--medium"
-            >
-              <legend
-                class="navds-fieldset__legend navds-label"
-              >
-                merOmSituasjonenDin.arbeidsforhold.ansettelsesforhold
-              </legend>
-              <div
-                class="navds-radio-buttons"
-              >
-                <div
-                  class="radioBorder navds-radio navds-radio--medium"
-                >
-                  <input
-                    aria-labelledby="r3q"
-                    class="navds-radio__input"
-                    id="radio-r3p"
-                    name="arbeidsforhold[0].ansettelsesforhold"
-                    type="radio"
-                    value="stillingType.fast"
-                  />
-                  <label
-                    class="navds-radio__label"
-                    for="radio-r3p"
-                  >
-                    <span
-                      class="navds-radio__content"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="navds-body-short navds-body-short--medium"
-                        id="r3q"
-                      >
-                        stillingType.fast
-                      </span>
-                    </span>
-                  </label>
-                </div>
-                <div
-                  class="radioBorder navds-radio navds-radio--medium"
-                >
-                  <input
-                    aria-labelledby="r3t"
-                    checked=""
-                    class="navds-radio__input"
-                    id="radio-r3s"
-                    name="arbeidsforhold[0].ansettelsesforhold"
-                    type="radio"
-                    value="stillingType.midlertidig"
-                  />
-                  <label
-                    class="navds-radio__label"
-                    for="radio-r3s"
-                  >
-                    <span
-                      class="navds-radio__content"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="navds-body-short navds-body-short--medium"
-                        id="r3t"
-                      >
-                        stillingType.midlertidig
-                      </span>
-                    </span>
-                  </label>
-                </div>
-                <div
-                  class="radioBorder navds-radio navds-radio--medium"
-                >
-                  <input
-                    aria-labelledby="r40"
-                    class="navds-radio__input"
-                    id="radio-r3v"
-                    name="arbeidsforhold[0].ansettelsesforhold"
-                    type="radio"
-                    value="stillingType.tilkallingsvikar"
-                  />
-                  <label
-                    class="navds-radio__label"
-                    for="radio-r3v"
-                  >
-                    <span
-                      class="navds-radio__content"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="navds-body-short navds-body-short--medium"
-                        id="r40"
-                      >
-                        stillingType.tilkallingsvikar
-                      </span>
-                    </span>
-                  </label>
-                </div>
-              </div>
-              <div
-                aria-live="polite"
-                aria-relevant="additions removals"
-                class="navds-fieldset__error"
-                id="fieldset-error-r3o"
-              />
-            </fieldset>
-          </div>
-        </div>
-        <fieldset
-          class="sc-blHHSb hqrzOP"
-        >
-          <div
-            style="display: none;"
+            class="navds-r-p navds-box navds-box-bg navds-box-border-color navds-box-border-width"
+            style="--__ac-r-p-xs: var(--a-spacing-4); --__ac-box-background: var(--a-surface-selected); --__ac-box-border-color: var(--a-border-info); --__ac-box-border-width: 0px 0px 0px 4px;"
           >
             <div
               class="sc-cHqXqK jvHoMc"
             >
-              <div
-                class="sc-cHqXqK jvHoMc"
-              >
-                <h1
-                  class="navds-heading navds-heading--small"
-                >
-                  merOmSituasjonenDin.arbeidsforhold.ansettelsesforhold.fast.tittel
-                </h1>
-                <p
-                  class="navds-body-short navds-body-short--medium"
-                >
-                  merOmSituasjonenDin.arbeidsforhold.ansettelsesforhold.fast.beskrivelse
-                </p>
-              </div>
-              <div
-                class="navds-form-field navds-form-field--medium"
-              >
-                <label
-                  class="navds-form-field__label navds-label"
-                  for="arbeidsforhold[0].arbeidsmengde.svar"
-                >
-                  merOmSituasjonenDin.arbeidsforhold.arbeidsmengde.svar.fast
-                </label>
-                <input
-                  aria-hidden="true"
-                  class="navds-text-field__input navds-body-short navds-body-short--medium"
-                  id="arbeidsforhold[0].arbeidsmengde.svar"
-                  size="10"
-                  type="text"
-                  value=""
-                />
-                <div
-                  aria-live="polite"
-                  aria-relevant="additions removals"
-                  class="navds-form-field__error"
-                  id="textField-error-r42"
-                />
-              </div>
-            </div>
-          </div>
-          <div
-            style="display: block;"
-          >
-            <div
-              class="sc-cHqXqK jvHoMc"
-            >
-              <div
-                class="sc-cHqXqK jvHoMc"
-              >
-                <h1
-                  class="navds-heading navds-heading--small"
-                >
-                  merOmSituasjonenDin.arbeidsforhold.ansettelsesforhold.fast.tittel
-                </h1>
-                <p
-                  class="navds-body-short navds-body-short--medium"
-                >
-                  merOmSituasjonenDin.arbeidsforhold.ansettelsesforhold.midlertidig.beskrivelse
-                </p>
-              </div>
-              <div
-                class="sc-dpBQxM cXcjLZ"
-              >
+              <div>
                 <div
                   class="navds-form-field navds-form-field--medium"
                 >
                   <label
                     class="navds-form-field__label navds-label"
-                    for="arbeidsforhold[0].arbeidsmengde.svar"
+                    for="arbeidsforhold[0].arbeidsgiver"
                   >
-                    merOmSituasjonenDin.arbeidsforhold.arbeidsmengde.svar
+                    merOmSituasjonenDin.arbeidsforhold.arbeidsgiver
                   </label>
                   <input
-                    aria-hidden="false"
                     class="navds-text-field__input navds-body-short navds-body-short--medium"
-                    id="arbeidsforhold[0].arbeidsmengde.svar"
-                    size="25"
+                    id="arbeidsforhold[0].arbeidsgiver"
+                    size="35"
                     type="text"
-                    value=""
+                    value="Potetskreller AS"
                   />
                   <div
                     aria-live="polite"
                     aria-relevant="additions removals"
                     class="navds-form-field__error"
-                    id="textField-error-r43"
+                    id="textField-error-r3m"
                   />
                 </div>
-                <div
-                  class="sc-cEzcPc guivVO"
-                  id="arbeidsforhold[0].arbeidsmengde.type"
+              </div>
+            </div>
+            <div
+              class="sc-cHqXqK jvHoMc"
+            >
+              <div
+                id="arbeidsforhold[0].ansettelsesforhold"
+              >
+                <fieldset
+                  class="navds-radio-group navds-radio-group--medium navds-fieldset navds-fieldset--medium"
                 >
+                  <legend
+                    class="navds-fieldset__legend navds-label"
+                  >
+                    merOmSituasjonenDin.arbeidsforhold.ansettelsesforhold
+                  </legend>
+                  <div
+                    class="navds-radio-buttons"
+                  >
+                    <div
+                      class="radioBorder navds-radio navds-radio--medium"
+                    >
+                      <input
+                        aria-labelledby="r3q"
+                        class="navds-radio__input"
+                        id="radio-r3p"
+                        name="arbeidsforhold[0].ansettelsesforhold"
+                        type="radio"
+                        value="stillingType.fast"
+                      />
+                      <label
+                        class="navds-radio__label"
+                        for="radio-r3p"
+                      >
+                        <span
+                          class="navds-radio__content"
+                        >
+                          <span
+                            aria-hidden="true"
+                            class="navds-body-short navds-body-short--medium"
+                            id="r3q"
+                          >
+                            stillingType.fast
+                          </span>
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      class="radioBorder navds-radio navds-radio--medium"
+                    >
+                      <input
+                        aria-labelledby="r3t"
+                        checked=""
+                        class="navds-radio__input"
+                        id="radio-r3s"
+                        name="arbeidsforhold[0].ansettelsesforhold"
+                        type="radio"
+                        value="stillingType.midlertidig"
+                      />
+                      <label
+                        class="navds-radio__label"
+                        for="radio-r3s"
+                      >
+                        <span
+                          class="navds-radio__content"
+                        >
+                          <span
+                            aria-hidden="true"
+                            class="navds-body-short navds-body-short--medium"
+                            id="r3t"
+                          >
+                            stillingType.midlertidig
+                          </span>
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      class="radioBorder navds-radio navds-radio--medium"
+                    >
+                      <input
+                        aria-labelledby="r40"
+                        class="navds-radio__input"
+                        id="radio-r3v"
+                        name="arbeidsforhold[0].ansettelsesforhold"
+                        type="radio"
+                        value="stillingType.tilkallingsvikar"
+                      />
+                      <label
+                        class="navds-radio__label"
+                        for="radio-r3v"
+                      >
+                        <span
+                          class="navds-radio__content"
+                        >
+                          <span
+                            aria-hidden="true"
+                            class="navds-body-short navds-body-short--medium"
+                            id="r40"
+                          >
+                            stillingType.tilkallingsvikar
+                          </span>
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                  <div
+                    aria-live="polite"
+                    aria-relevant="additions removals"
+                    class="navds-fieldset__error"
+                    id="fieldset-error-r3o"
+                  />
+                </fieldset>
+              </div>
+            </div>
+            <fieldset
+              class="sc-blHHSb hqrzOP"
+            >
+              <div
+                style="display: none;"
+              >
+                <div
+                  class="sc-cHqXqK jvHoMc"
+                >
+                  <div
+                    class="sc-cHqXqK jvHoMc"
+                  >
+                    <h1
+                      class="navds-heading navds-heading--small"
+                    >
+                      merOmSituasjonenDin.arbeidsforhold.ansettelsesforhold.fast.tittel
+                    </h1>
+                    <p
+                      class="navds-body-short navds-body-short--medium"
+                    >
+                      merOmSituasjonenDin.arbeidsforhold.ansettelsesforhold.fast.beskrivelse
+                    </p>
+                  </div>
                   <div
                     class="navds-form-field navds-form-field--medium"
                   >
                     <label
                       class="navds-form-field__label navds-label"
-                      for="select-r44"
+                      for="arbeidsforhold[0].arbeidsmengde.svar"
                     >
-                      felles.velg.tittel
+                      merOmSituasjonenDin.arbeidsforhold.arbeidsmengde.svar.fast
                     </label>
-                    <div
-                      class="navds-select__container"
-                    >
-                      <select
-                        aria-hidden="false"
-                        class="navds-select__input navds-body-short navds-body-short--medium"
-                        id="select-r44"
-                      >
-                        <option
-                          value=""
-                        >
-                          felles.velg
-                        </option>
-                        <option
-                          value="arbeidsmengde.prosent"
-                        >
-                          arbeidsmengde.prosent
-                        </option>
-                        <option
-                          value="arbeidsmengde.timer"
-                        >
-                          arbeidsmengde.timer
-                        </option>
-                      </select>
-                      <svg
-                        aria-hidden="true"
-                        class="navds-select__chevron"
-                        fill="none"
-                        focusable="false"
-                        height="1em"
-                        role="img"
-                        viewBox="0 0 24 24"
-                        width="1em"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          clip-rule="evenodd"
-                          d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
-                          fill="currentColor"
-                          fill-rule="evenodd"
-                        />
-                      </svg>
-                    </div>
+                    <input
+                      aria-hidden="true"
+                      class="navds-text-field__input navds-body-short navds-body-short--medium"
+                      id="arbeidsforhold[0].arbeidsmengde.svar"
+                      size="10"
+                      type="text"
+                      value=""
+                    />
                     <div
                       aria-live="polite"
                       aria-relevant="additions removals"
                       class="navds-form-field__error"
-                      id="select-error-r44"
+                      id="textField-error-r42"
                     />
                   </div>
                 </div>
               </div>
               <div
-                class="sc-cHqXqK jvHoMc"
+                style="display: block;"
               >
                 <div
-                  id="arbeidsforhold[0].midlertidig.svar"
-                >
-                  <fieldset
-                    class="navds-radio-group navds-radio-group--medium navds-fieldset navds-fieldset--medium"
-                  >
-                    <legend
-                      class="navds-fieldset__legend navds-label"
-                    >
-                      merOmSituasjonenDin.arbeidsforhold.midlertidig.svar
-                    </legend>
-                    <div
-                      class="navds-radio-buttons"
-                    >
-                      <div
-                        class="radioBorder navds-radio navds-radio--medium"
-                      >
-                        <input
-                          aria-labelledby="r49"
-                          class="navds-radio__input"
-                          id="radio-r48"
-                          name="arbeidsforhold[0].midlertidig.svar"
-                          type="radio"
-                          value="radiobuttons.ja"
-                        />
-                        <label
-                          class="navds-radio__label"
-                          for="radio-r48"
-                        >
-                          <span
-                            class="navds-radio__content"
-                          >
-                            <span
-                              aria-hidden="true"
-                              class="navds-body-short navds-body-short--medium"
-                              id="r49"
-                            >
-                              radiobuttons.ja
-                            </span>
-                          </span>
-                        </label>
-                      </div>
-                      <div
-                        class="radioBorder navds-radio navds-radio--medium"
-                      >
-                        <input
-                          aria-labelledby="r4c"
-                          class="navds-radio__input"
-                          id="radio-r4b"
-                          name="arbeidsforhold[0].midlertidig.svar"
-                          type="radio"
-                          value="radiobuttons.nei"
-                        />
-                        <label
-                          class="navds-radio__label"
-                          for="radio-r4b"
-                        >
-                          <span
-                            class="navds-radio__content"
-                          >
-                            <span
-                              aria-hidden="true"
-                              class="navds-body-short navds-body-short--medium"
-                              id="r4c"
-                            >
-                              radiobuttons.nei
-                            </span>
-                          </span>
-                        </label>
-                      </div>
-                    </div>
-                    <div
-                      aria-live="polite"
-                      aria-relevant="additions removals"
-                      class="navds-fieldset__error"
-                      id="fieldset-error-r47"
-                    />
-                  </fieldset>
-                </div>
-              </div>
-              <div
-                style="display: none;"
-              >
-                <section
-                  class="sc-jtQUzJ cfiJNq"
+                  class="sc-cHqXqK jvHoMc"
                 >
                   <div
-                    class="navds-date__wrapper"
+                    class="sc-cHqXqK jvHoMc"
+                  >
+                    <h1
+                      class="navds-heading navds-heading--small"
+                    >
+                      merOmSituasjonenDin.arbeidsforhold.ansettelsesforhold.fast.tittel
+                    </h1>
+                    <p
+                      class="navds-body-short navds-body-short--medium"
+                    >
+                      merOmSituasjonenDin.arbeidsforhold.ansettelsesforhold.midlertidig.beskrivelse
+                    </p>
+                  </div>
+                  <div
+                    class="sc-dpBQxM cXcjLZ"
                   >
                     <div
-                      class="navds-form-field navds-form-field--medium navds-date__field"
+                      class="navds-form-field navds-form-field--medium"
                     >
                       <label
                         class="navds-form-field__label navds-label"
-                        for="arbeidsforhold[0].midlertidig.sluttdatoVelger"
+                        for="arbeidsforhold[0].arbeidsmengde.svar"
                       >
-                        merOmSituasjonenDin.arbeidsforhold.midlertidig.sluttdatoVelger (felles.valgfri)
+                        merOmSituasjonenDin.arbeidsforhold.arbeidsmengde.svar
                       </label>
+                      <input
+                        aria-hidden="false"
+                        class="navds-text-field__input navds-body-short navds-body-short--medium"
+                        id="arbeidsforhold[0].arbeidsmengde.svar"
+                        size="25"
+                        type="text"
+                        value=""
+                      />
                       <div
-                        class="navds-form-field__description navds-body-short navds-body-short--medium"
-                        id="datepicker-input-description-r4f"
-                      >
-                        felles.oppgiDato felles.datoformat
-                      </div>
+                        aria-live="polite"
+                        aria-relevant="additions removals"
+                        class="navds-form-field__error"
+                        id="textField-error-r43"
+                      />
+                    </div>
+                    <div
+                      class="sc-cEzcPc guivVO"
+                      id="arbeidsforhold[0].arbeidsmengde.type"
+                    >
                       <div
-                        class="navds-date__field-wrapper"
+                        class="navds-form-field navds-form-field--medium"
                       >
-                        <input
-                          aria-describedby="datepicker-input-description-r4f"
-                          autocomplete="off"
-                          class="navds-date__field-input navds-text-field__input navds-body-short navds-body-short--medium"
-                          id="arbeidsforhold[0].midlertidig.sluttdatoVelger"
-                          size="11"
-                          value=""
-                        />
-                        <button
-                          class="navds-date__field-button"
-                          tabindex="0"
-                          type="button"
+                        <label
+                          class="navds-form-field__label navds-label"
+                          for="select-r44"
                         >
+                          felles.velg.tittel
+                        </label>
+                        <div
+                          class="navds-select__container"
+                        >
+                          <select
+                            aria-hidden="false"
+                            class="navds-select__input navds-body-short navds-body-short--medium"
+                            id="select-r44"
+                          >
+                            <option
+                              value=""
+                            >
+                              felles.velg
+                            </option>
+                            <option
+                              value="arbeidsmengde.prosent"
+                            >
+                              arbeidsmengde.prosent
+                            </option>
+                            <option
+                              value="arbeidsmengde.timer"
+                            >
+                              arbeidsmengde.timer
+                            </option>
+                          </select>
                           <svg
-                            aria-labelledby="title-r4g"
+                            aria-hidden="true"
+                            class="navds-select__chevron"
                             fill="none"
                             focusable="false"
                             height="1em"
-                            pointer-events="none"
                             role="img"
                             viewBox="0 0 24 24"
                             width="1em"
                             xmlns="http://www.w3.org/2000/svg"
                           >
-                            <title
-                              id="title-r4g"
-                            >
-                              Åpne datovelger
-                            </title>
                             <path
                               clip-rule="evenodd"
-                              d="M9 2.25a.75.75 0 0 1 .75.75v1.25h4.5V3a.75.75 0 0 1 1.5 0v1.25h3.75c.69 0 1.25.56 1.25 1.25v13c0 .69-.56 1.25-1.25 1.25h-15c-.69 0-1.25-.56-1.25-1.25v-13c0-.69.56-1.25 1.25-1.25h3.75V3A.75.75 0 0 1 9 2.25M15.75 7a.75.75 0 0 1-1.5 0V5.75h-4.5V7a.75.75 0 0 1-1.5 0V5.75h-3.5v3.5h14.5v-3.5h-3.5zm-11 11.25v-7.5h14.5v7.5zm2-5.25a.75.75 0 0 1 .75-.75h1a.75.75 0 0 1 0 1.5h-1a.75.75 0 0 1-.75-.75m4 0a.75.75 0 0 1 .75-.75h1a.75.75 0 0 1 0 1.5h-1a.75.75 0 0 1-.75-.75m4.75-.75a.75.75 0 0 0 0 1.5h1a.75.75 0 0 0 0-1.5zM10.75 16a.75.75 0 0 1 .75-.75h1a.75.75 0 0 1 0 1.5h-1a.75.75 0 0 1-.75-.75m4.75-.75a.75.75 0 0 0 0 1.5h1a.75.75 0 0 0 0-1.5zM6.75 16a.75.75 0 0 1 .75-.75h1a.75.75 0 0 1 0 1.5h-1a.75.75 0 0 1-.75-.75"
+                              d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
                               fill="currentColor"
                               fill-rule="evenodd"
                             />
                           </svg>
-                        </button>
+                        </div>
+                        <div
+                          aria-live="polite"
+                          aria-relevant="additions removals"
+                          class="navds-form-field__error"
+                          id="select-error-r44"
+                        />
                       </div>
+                    </div>
+                  </div>
+                  <div
+                    class="sc-cHqXqK jvHoMc"
+                  >
+                    <div
+                      id="arbeidsforhold[0].midlertidig.svar"
+                    >
+                      <fieldset
+                        class="navds-radio-group navds-radio-group--medium navds-fieldset navds-fieldset--medium"
+                      >
+                        <legend
+                          class="navds-fieldset__legend navds-label"
+                        >
+                          merOmSituasjonenDin.arbeidsforhold.midlertidig.svar
+                        </legend>
+                        <div
+                          class="navds-radio-buttons"
+                        >
+                          <div
+                            class="radioBorder navds-radio navds-radio--medium"
+                          >
+                            <input
+                              aria-labelledby="r49"
+                              class="navds-radio__input"
+                              id="radio-r48"
+                              name="arbeidsforhold[0].midlertidig.svar"
+                              type="radio"
+                              value="radiobuttons.ja"
+                            />
+                            <label
+                              class="navds-radio__label"
+                              for="radio-r48"
+                            >
+                              <span
+                                class="navds-radio__content"
+                              >
+                                <span
+                                  aria-hidden="true"
+                                  class="navds-body-short navds-body-short--medium"
+                                  id="r49"
+                                >
+                                  radiobuttons.ja
+                                </span>
+                              </span>
+                            </label>
+                          </div>
+                          <div
+                            class="radioBorder navds-radio navds-radio--medium"
+                          >
+                            <input
+                              aria-labelledby="r4c"
+                              class="navds-radio__input"
+                              id="radio-r4b"
+                              name="arbeidsforhold[0].midlertidig.svar"
+                              type="radio"
+                              value="radiobuttons.nei"
+                            />
+                            <label
+                              class="navds-radio__label"
+                              for="radio-r4b"
+                            >
+                              <span
+                                class="navds-radio__content"
+                              >
+                                <span
+                                  aria-hidden="true"
+                                  class="navds-body-short navds-body-short--medium"
+                                  id="r4c"
+                                >
+                                  radiobuttons.nei
+                                </span>
+                              </span>
+                            </label>
+                          </div>
+                        </div>
+                        <div
+                          aria-live="polite"
+                          aria-relevant="additions removals"
+                          class="navds-fieldset__error"
+                          id="fieldset-error-r47"
+                        />
+                      </fieldset>
+                    </div>
+                  </div>
+                  <div
+                    style="display: none;"
+                  >
+                    <section
+                      class="sc-jtQUzJ cfiJNq"
+                    >
+                      <div
+                        class="navds-date__wrapper"
+                      >
+                        <div
+                          class="navds-form-field navds-form-field--medium navds-date__field"
+                        >
+                          <label
+                            class="navds-form-field__label navds-label"
+                            for="arbeidsforhold[0].midlertidig.sluttdatoVelger"
+                          >
+                            merOmSituasjonenDin.arbeidsforhold.midlertidig.sluttdatoVelger (felles.valgfri)
+                          </label>
+                          <div
+                            class="navds-form-field__description navds-body-short navds-body-short--medium"
+                            id="datepicker-input-description-r4f"
+                          >
+                            felles.oppgiDato felles.datoformat
+                          </div>
+                          <div
+                            class="navds-date__field-wrapper"
+                          >
+                            <input
+                              aria-describedby="datepicker-input-description-r4f"
+                              autocomplete="off"
+                              class="navds-date__field-input navds-text-field__input navds-body-short navds-body-short--medium"
+                              id="arbeidsforhold[0].midlertidig.sluttdatoVelger"
+                              size="11"
+                              value=""
+                            />
+                            <button
+                              class="navds-date__field-button"
+                              tabindex="0"
+                              type="button"
+                            >
+                              <svg
+                                aria-labelledby="title-r4g"
+                                fill="none"
+                                focusable="false"
+                                height="1em"
+                                pointer-events="none"
+                                role="img"
+                                viewBox="0 0 24 24"
+                                width="1em"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <title
+                                  id="title-r4g"
+                                >
+                                  Åpne datovelger
+                                </title>
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M9 2.25a.75.75 0 0 1 .75.75v1.25h4.5V3a.75.75 0 0 1 1.5 0v1.25h3.75c.69 0 1.25.56 1.25 1.25v13c0 .69-.56 1.25-1.25 1.25h-15c-.69 0-1.25-.56-1.25-1.25v-13c0-.69.56-1.25 1.25-1.25h3.75V3A.75.75 0 0 1 9 2.25M15.75 7a.75.75 0 0 1-1.5 0V5.75h-4.5V7a.75.75 0 0 1-1.5 0V5.75h-3.5v3.5h14.5v-3.5h-3.5zm-11 11.25v-7.5h14.5v7.5zm2-5.25a.75.75 0 0 1 .75-.75h1a.75.75 0 0 1 0 1.5h-1a.75.75 0 0 1-.75-.75m4 0a.75.75 0 0 1 .75-.75h1a.75.75 0 0 1 0 1.5h-1a.75.75 0 0 1-.75-.75m4.75-.75a.75.75 0 0 0 0 1.5h1a.75.75 0 0 0 0-1.5zM10.75 16a.75.75 0 0 1 .75-.75h1a.75.75 0 0 1 0 1.5h-1a.75.75 0 0 1-.75-.75m4.75-.75a.75.75 0 0 0 0 1.5h1a.75.75 0 0 0 0-1.5zM6.75 16a.75.75 0 0 1 .75-.75h1a.75.75 0 0 1 0 1.5h-1a.75.75 0 0 1-.75-.75"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                          <div
+                            aria-live="polite"
+                            aria-relevant="additions removals"
+                            class="navds-form-field__error"
+                            id="datepicker-input-error-r4f"
+                          />
+                        </div>
+                        <div
+                          aria-hidden="true"
+                          class="navds-popover navds-date__popover navds-popover--hidden"
+                          data-index="0"
+                          data-placement="bottom-start"
+                          id="r4e"
+                          role="dialog"
+                          style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 0px);"
+                        >
+                          <div
+                            class="rdp navds-date"
+                          >
+                            <div
+                              class="rdp-months"
+                            >
+                              <div
+                                class="rdp-month rdp-caption_start rdp-caption_end"
+                              >
+                                <div
+                                  class="navds-date__caption"
+                                >
+                                  <span
+                                    aria-atomic="true"
+                                    aria-live="polite"
+                                    class="navds-sr-only"
+                                    id="react-day-picker-4"
+                                  >
+                                    januar 2024
+                                  </span>
+                                  <button
+                                    class="navds-date__caption-button navds-button navds-button--tertiary navds-button--medium navds-button--icon-only navds-button--disabled"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    <span
+                                      class="navds-button__icon"
+                                    >
+                                      <svg
+                                        aria-labelledby="title-r4i"
+                                        fill="none"
+                                        focusable="false"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 24 24"
+                                        width="1em"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <title
+                                          id="title-r4i"
+                                        >
+                                          Gå til forrige måned
+                                        </title>
+                                        <path
+                                          d="M4.47 11.47a.75.75 0 0 0 0 1.06l4.5 4.5a.75.75 0 0 0 1.06-1.06l-3.22-3.22H19a.75.75 0 0 0 0-1.5H6.81l3.22-3.22a.75.75 0 1 0-1.06-1.06z"
+                                          fill="currentColor"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </button>
+                                  <div
+                                    class="navds-date__caption"
+                                  >
+                                    <div
+                                      class="navds-date__caption__month navds-form-field navds-form-field--medium"
+                                    >
+                                      <label
+                                        class="navds-form-field__label navds-sr-only navds-label"
+                                        for="select-r4j"
+                                      >
+                                        Måned
+                                      </label>
+                                      <div
+                                        class="navds-select__container"
+                                      >
+                                        <select
+                                          class="navds-select__input navds-body-short navds-body-short--medium"
+                                          id="select-r4j"
+                                        >
+                                          <option
+                                            value="0"
+                                          >
+                                            januar
+                                          </option>
+                                          <option
+                                            value="1"
+                                          >
+                                            februar
+                                          </option>
+                                          <option
+                                            value="2"
+                                          >
+                                            mars
+                                          </option>
+                                          <option
+                                            value="3"
+                                          >
+                                            april
+                                          </option>
+                                          <option
+                                            value="4"
+                                          >
+                                            mai
+                                          </option>
+                                          <option
+                                            value="5"
+                                          >
+                                            juni
+                                          </option>
+                                          <option
+                                            value="6"
+                                          >
+                                            juli
+                                          </option>
+                                          <option
+                                            value="7"
+                                          >
+                                            august
+                                          </option>
+                                          <option
+                                            value="8"
+                                          >
+                                            september
+                                          </option>
+                                          <option
+                                            value="9"
+                                          >
+                                            oktober
+                                          </option>
+                                          <option
+                                            value="10"
+                                          >
+                                            november
+                                          </option>
+                                          <option
+                                            value="11"
+                                          >
+                                            desember
+                                          </option>
+                                        </select>
+                                        <svg
+                                          aria-hidden="true"
+                                          class="navds-select__chevron"
+                                          fill="none"
+                                          focusable="false"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 24 24"
+                                          width="1em"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            clip-rule="evenodd"
+                                            d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
+                                            fill="currentColor"
+                                            fill-rule="evenodd"
+                                          />
+                                        </svg>
+                                      </div>
+                                      <div
+                                        aria-live="polite"
+                                        aria-relevant="additions removals"
+                                        class="navds-form-field__error"
+                                        id="select-error-r4j"
+                                      />
+                                    </div>
+                                    <div
+                                      class="navds-date__caption__year navds-form-field navds-form-field--medium"
+                                    >
+                                      <label
+                                        class="navds-form-field__label navds-sr-only navds-label"
+                                        for="select-r4l"
+                                      >
+                                        År
+                                      </label>
+                                      <div
+                                        class="navds-select__container"
+                                      >
+                                        <select
+                                          class="navds-select__input navds-body-short navds-body-short--medium"
+                                          id="select-r4l"
+                                        >
+                                          <option
+                                            value="2044"
+                                          >
+                                            2044
+                                          </option>
+                                          <option
+                                            value="2043"
+                                          >
+                                            2043
+                                          </option>
+                                          <option
+                                            value="2042"
+                                          >
+                                            2042
+                                          </option>
+                                          <option
+                                            value="2041"
+                                          >
+                                            2041
+                                          </option>
+                                          <option
+                                            value="2040"
+                                          >
+                                            2040
+                                          </option>
+                                          <option
+                                            value="2039"
+                                          >
+                                            2039
+                                          </option>
+                                          <option
+                                            value="2038"
+                                          >
+                                            2038
+                                          </option>
+                                          <option
+                                            value="2037"
+                                          >
+                                            2037
+                                          </option>
+                                          <option
+                                            value="2036"
+                                          >
+                                            2036
+                                          </option>
+                                          <option
+                                            value="2035"
+                                          >
+                                            2035
+                                          </option>
+                                          <option
+                                            value="2034"
+                                          >
+                                            2034
+                                          </option>
+                                          <option
+                                            value="2033"
+                                          >
+                                            2033
+                                          </option>
+                                          <option
+                                            value="2032"
+                                          >
+                                            2032
+                                          </option>
+                                          <option
+                                            value="2031"
+                                          >
+                                            2031
+                                          </option>
+                                          <option
+                                            value="2030"
+                                          >
+                                            2030
+                                          </option>
+                                          <option
+                                            value="2029"
+                                          >
+                                            2029
+                                          </option>
+                                          <option
+                                            value="2028"
+                                          >
+                                            2028
+                                          </option>
+                                          <option
+                                            value="2027"
+                                          >
+                                            2027
+                                          </option>
+                                          <option
+                                            value="2026"
+                                          >
+                                            2026
+                                          </option>
+                                          <option
+                                            value="2025"
+                                          >
+                                            2025
+                                          </option>
+                                          <option
+                                            value="2024"
+                                          >
+                                            2024
+                                          </option>
+                                        </select>
+                                        <svg
+                                          aria-hidden="true"
+                                          class="navds-select__chevron"
+                                          fill="none"
+                                          focusable="false"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 24 24"
+                                          width="1em"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            clip-rule="evenodd"
+                                            d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
+                                            fill="currentColor"
+                                            fill-rule="evenodd"
+                                          />
+                                        </svg>
+                                      </div>
+                                      <div
+                                        aria-live="polite"
+                                        aria-relevant="additions removals"
+                                        class="navds-form-field__error"
+                                        id="select-error-r4l"
+                                      />
+                                    </div>
+                                  </div>
+                                  <button
+                                    class="navds-date__caption-button navds-button navds-button--tertiary navds-button--medium navds-button--icon-only"
+                                    type="button"
+                                  >
+                                    <span
+                                      class="navds-button__icon"
+                                    >
+                                      <svg
+                                        aria-labelledby="title-r4n"
+                                        fill="none"
+                                        focusable="false"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 24 24"
+                                        width="1em"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <title
+                                          id="title-r4n"
+                                        >
+                                          Gå til neste måned
+                                        </title>
+                                        <path
+                                          d="M14.087 6.874a.752.752 0 0 0-.117 1.156l3.22 3.22H5a.75.75 0 0 0 0 1.5h12.19l-3.22 3.22a.75.75 0 0 0 1.06 1.06l4.5-4.5a.75.75 0 0 0 0-1.06l-4.5-4.5a.75.75 0 0 0-.943-.096"
+                                          fill="currentColor"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </button>
+                                </div>
+                                <table
+                                  aria-labelledby="react-day-picker-4"
+                                  class="rdp-table"
+                                  role="grid"
+                                >
+                                  <thead
+                                    aria-hidden="true"
+                                    class="rdp-head"
+                                  >
+                                    <tr
+                                      class="rdp-head_row"
+                                    >
+                                      <th
+                                        aria-label="mandag"
+                                        class="rdp-head_cell"
+                                        scope="col"
+                                      >
+                                        ma
+                                      </th>
+                                      <th
+                                        aria-label="tirsdag"
+                                        class="rdp-head_cell"
+                                        scope="col"
+                                      >
+                                        ti
+                                      </th>
+                                      <th
+                                        aria-label="onsdag"
+                                        class="rdp-head_cell"
+                                        scope="col"
+                                      >
+                                        on
+                                      </th>
+                                      <th
+                                        aria-label="torsdag"
+                                        class="rdp-head_cell"
+                                        scope="col"
+                                      >
+                                        to
+                                      </th>
+                                      <th
+                                        aria-label="fredag"
+                                        class="rdp-head_cell"
+                                        scope="col"
+                                      >
+                                        fr
+                                      </th>
+                                      <th
+                                        aria-label="lørdag"
+                                        class="rdp-head_cell"
+                                        scope="col"
+                                      >
+                                        lø
+                                      </th>
+                                      <th
+                                        aria-label="søndag"
+                                        class="rdp-head_cell"
+                                        scope="col"
+                                      >
+                                        sø
+                                      </th>
+                                    </tr>
+                                  </thead>
+                                  <tbody
+                                    class="rdp-tbody"
+                                  >
+                                    <tr
+                                      class="rdp-row"
+                                    >
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="mandag 1"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day rdp-day_today"
+                                          name="day"
+                                          tabindex="0"
+                                          type="button"
+                                        >
+                                          1
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="tirsdag 2"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          2
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="onsdag 3"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          3
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="torsdag 4"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          4
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="fredag 5"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          5
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="lørdag 6"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          6
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="søndag 7"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          7
+                                        </button>
+                                      </td>
+                                    </tr>
+                                    <tr
+                                      class="rdp-row"
+                                    >
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="mandag 8"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          8
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="tirsdag 9"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          9
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="onsdag 10"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          10
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="torsdag 11"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          11
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="fredag 12"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          12
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="lørdag 13"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          13
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="søndag 14"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          14
+                                        </button>
+                                      </td>
+                                    </tr>
+                                    <tr
+                                      class="rdp-row"
+                                    >
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="mandag 15"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          15
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="tirsdag 16"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          16
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="onsdag 17"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          17
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="torsdag 18"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          18
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="fredag 19"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          19
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="lørdag 20"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          20
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="søndag 21"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          21
+                                        </button>
+                                      </td>
+                                    </tr>
+                                    <tr
+                                      class="rdp-row"
+                                    >
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="mandag 22"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          22
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="tirsdag 23"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          23
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="onsdag 24"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          24
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="torsdag 25"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          25
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="fredag 26"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          26
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="lørdag 27"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          27
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="søndag 28"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          28
+                                        </button>
+                                      </td>
+                                    </tr>
+                                    <tr
+                                      class="rdp-row"
+                                    >
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="mandag 29"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          29
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="tirsdag 30"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          30
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="onsdag 31"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          31
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-hidden="true"
+                                          aria-label="torsdag 1"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          1
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-hidden="true"
+                                          aria-label="fredag 2"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          2
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-hidden="true"
+                                          aria-label="lørdag 3"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          3
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-hidden="true"
+                                          aria-label="søndag 4"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          4
+                                        </button>
+                                      </td>
+                                    </tr>
+                                    <tr
+                                      class="rdp-row"
+                                    >
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-hidden="true"
+                                          aria-label="mandag 5"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          5
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-hidden="true"
+                                          aria-label="tirsdag 6"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          6
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-hidden="true"
+                                          aria-label="onsdag 7"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          7
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-hidden="true"
+                                          aria-label="torsdag 8"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          8
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-hidden="true"
+                                          aria-label="fredag 9"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          9
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-hidden="true"
+                                          aria-label="lørdag 10"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          10
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-hidden="true"
+                                          aria-label="søndag 11"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          11
+                                        </button>
+                                      </td>
+                                    </tr>
+                                  </tbody>
+                                </table>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </section>
+                  </div>
+                </div>
+              </div>
+            </fieldset>
+            <fieldset
+              class="sc-blHHSb hqrzOP"
+            >
+              <div
+                id="arbeidsforhold[0].forventerEndretArbeidssituasjon.svar"
+              >
+                <fieldset
+                  class="navds-radio-group navds-radio-group--medium navds-fieldset navds-fieldset--medium"
+                >
+                  <legend
+                    class="navds-fieldset__legend navds-label"
+                  >
+                    merOmSituasjonenDin.arbeidsforhold.forventerEndretArbeidssituasjon.svar
+                  </legend>
+                  <div
+                    class="navds-radio-buttons"
+                  >
+                    <div
+                      class="radioBorder navds-radio navds-radio--medium"
+                    >
+                      <input
+                        aria-labelledby="r4s"
+                        class="navds-radio__input"
+                        id="radio-r4r"
+                        name="arbeidsforhold[0].forventerEndretArbeidssituasjon.svar"
+                        type="radio"
+                        value="radiobuttons.ja"
+                      />
+                      <label
+                        class="navds-radio__label"
+                        for="radio-r4r"
+                      >
+                        <span
+                          class="navds-radio__content"
+                        >
+                          <span
+                            aria-hidden="true"
+                            class="navds-body-short navds-body-short--medium"
+                            id="r4s"
+                          >
+                            radiobuttons.ja
+                          </span>
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      class="radioBorder navds-radio navds-radio--medium"
+                    >
+                      <input
+                        aria-labelledby="r4v"
+                        class="navds-radio__input"
+                        id="radio-r4u"
+                        name="arbeidsforhold[0].forventerEndretArbeidssituasjon.svar"
+                        type="radio"
+                        value="radiobuttons.nei"
+                      />
+                      <label
+                        class="navds-radio__label"
+                        for="radio-r4u"
+                      >
+                        <span
+                          class="navds-radio__content"
+                        >
+                          <span
+                            aria-hidden="true"
+                            class="navds-body-short navds-body-short--medium"
+                            id="r4v"
+                          >
+                            radiobuttons.nei
+                          </span>
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                  <div
+                    aria-live="polite"
+                    aria-relevant="additions removals"
+                    class="navds-fieldset__error"
+                    id="fieldset-error-r4q"
+                  />
+                </fieldset>
+              </div>
+              <div
+                style="display: none;"
+              >
+                <div
+                  class="sc-cHqXqK jvHoMc"
+                >
+                  <div
+                    class="width-50"
+                  >
+                    <div
+                      class="navds-form-field navds-form-field--medium"
+                    >
+                      <label
+                        class="navds-form-field__label navds-label"
+                        for="arbeidsforhold[0].forventerEndretArbeidssituasjon.beskrivelse"
+                      >
+                        merOmSituasjonenDin.arbeidsforhold.forventerEndretArbeidssituasjon.beskrivelse
+                      </label>
+                      <div
+                        class="navds-form-field__description navds-body-short navds-body-short--medium"
+                        id="textarea-description-r51"
+                      >
+                        felles.ikkeSensitiveOpplysninger
+                      </div>
+                      <textarea
+                        aria-describedby="textarea-description-r51 r52"
+                        class="navds-textarea__input navds-body-short navds-body-short--medium"
+                        id="arbeidsforhold[0].forventerEndretArbeidssituasjon.beskrivelse"
+                        rows="3"
+                        style="--__ac-textarea-height: -4px; overflow: hidden;"
+                      />
+                      <textarea
+                        aria-hidden="true"
+                        class="navds-textarea__input navds-body-short navds-body-short--medium"
+                        readonly=""
+                        style="visibility: hidden; position: absolute; overflow: hidden; height: 0px; top: 0px; left: 0px; transform: translateZ(0);"
+                        tabindex="-1"
+                      />
+                      <span
+                        class="navds-sr-only"
+                        id="r52"
+                      >
+                        Tekstområde med plass til 200 tegn.
+                      </span>
+                      <p
+                        class="navds-textarea__counter navds-body-short navds-body-short--medium"
+                      >
+                        200 counterLeft
+                      </p>
                       <div
                         aria-live="polite"
                         aria-relevant="additions removals"
                         class="navds-form-field__error"
-                        id="datepicker-input-error-r4f"
+                        id="textarea-error-r51"
                       />
                     </div>
-                    <div
-                      aria-hidden="true"
-                      class="navds-popover navds-date__popover navds-popover--hidden"
-                      data-index="0"
-                      data-placement="bottom-start"
-                      id="r4e"
-                      role="dialog"
-                      style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 0px);"
-                    >
-                      <div
-                        class="rdp navds-date"
-                      >
-                        <div
-                          class="rdp-months"
-                        >
-                          <div
-                            class="rdp-month rdp-caption_start rdp-caption_end"
-                          >
-                            <div
-                              class="navds-date__caption"
-                            >
-                              <span
-                                aria-atomic="true"
-                                aria-live="polite"
-                                class="navds-sr-only"
-                                id="react-day-picker-4"
-                              >
-                                januar 2024
-                              </span>
-                              <button
-                                class="navds-date__caption-button navds-button navds-button--tertiary navds-button--medium navds-button--icon-only navds-button--disabled"
-                                disabled=""
-                                type="button"
-                              >
-                                <span
-                                  class="navds-button__icon"
-                                >
-                                  <svg
-                                    aria-labelledby="title-r4i"
-                                    fill="none"
-                                    focusable="false"
-                                    height="1em"
-                                    role="img"
-                                    viewBox="0 0 24 24"
-                                    width="1em"
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <title
-                                      id="title-r4i"
-                                    >
-                                      Gå til forrige måned
-                                    </title>
-                                    <path
-                                      d="M4.47 11.47a.75.75 0 0 0 0 1.06l4.5 4.5a.75.75 0 0 0 1.06-1.06l-3.22-3.22H19a.75.75 0 0 0 0-1.5H6.81l3.22-3.22a.75.75 0 1 0-1.06-1.06z"
-                                      fill="currentColor"
-                                    />
-                                  </svg>
-                                </span>
-                              </button>
-                              <div
-                                class="navds-date__caption"
-                              >
-                                <div
-                                  class="navds-date__caption__month navds-form-field navds-form-field--medium"
-                                >
-                                  <label
-                                    class="navds-form-field__label navds-sr-only navds-label"
-                                    for="select-r4j"
-                                  >
-                                    Måned
-                                  </label>
-                                  <div
-                                    class="navds-select__container"
-                                  >
-                                    <select
-                                      class="navds-select__input navds-body-short navds-body-short--medium"
-                                      id="select-r4j"
-                                    >
-                                      <option
-                                        value="0"
-                                      >
-                                        januar
-                                      </option>
-                                      <option
-                                        value="1"
-                                      >
-                                        februar
-                                      </option>
-                                      <option
-                                        value="2"
-                                      >
-                                        mars
-                                      </option>
-                                      <option
-                                        value="3"
-                                      >
-                                        april
-                                      </option>
-                                      <option
-                                        value="4"
-                                      >
-                                        mai
-                                      </option>
-                                      <option
-                                        value="5"
-                                      >
-                                        juni
-                                      </option>
-                                      <option
-                                        value="6"
-                                      >
-                                        juli
-                                      </option>
-                                      <option
-                                        value="7"
-                                      >
-                                        august
-                                      </option>
-                                      <option
-                                        value="8"
-                                      >
-                                        september
-                                      </option>
-                                      <option
-                                        value="9"
-                                      >
-                                        oktober
-                                      </option>
-                                      <option
-                                        value="10"
-                                      >
-                                        november
-                                      </option>
-                                      <option
-                                        value="11"
-                                      >
-                                        desember
-                                      </option>
-                                    </select>
-                                    <svg
-                                      aria-hidden="true"
-                                      class="navds-select__chevron"
-                                      fill="none"
-                                      focusable="false"
-                                      height="1em"
-                                      role="img"
-                                      viewBox="0 0 24 24"
-                                      width="1em"
-                                      xmlns="http://www.w3.org/2000/svg"
-                                    >
-                                      <path
-                                        clip-rule="evenodd"
-                                        d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
-                                        fill="currentColor"
-                                        fill-rule="evenodd"
-                                      />
-                                    </svg>
-                                  </div>
-                                  <div
-                                    aria-live="polite"
-                                    aria-relevant="additions removals"
-                                    class="navds-form-field__error"
-                                    id="select-error-r4j"
-                                  />
-                                </div>
-                                <div
-                                  class="navds-date__caption__year navds-form-field navds-form-field--medium"
-                                >
-                                  <label
-                                    class="navds-form-field__label navds-sr-only navds-label"
-                                    for="select-r4l"
-                                  >
-                                    År
-                                  </label>
-                                  <div
-                                    class="navds-select__container"
-                                  >
-                                    <select
-                                      class="navds-select__input navds-body-short navds-body-short--medium"
-                                      id="select-r4l"
-                                    >
-                                      <option
-                                        value="2044"
-                                      >
-                                        2044
-                                      </option>
-                                      <option
-                                        value="2043"
-                                      >
-                                        2043
-                                      </option>
-                                      <option
-                                        value="2042"
-                                      >
-                                        2042
-                                      </option>
-                                      <option
-                                        value="2041"
-                                      >
-                                        2041
-                                      </option>
-                                      <option
-                                        value="2040"
-                                      >
-                                        2040
-                                      </option>
-                                      <option
-                                        value="2039"
-                                      >
-                                        2039
-                                      </option>
-                                      <option
-                                        value="2038"
-                                      >
-                                        2038
-                                      </option>
-                                      <option
-                                        value="2037"
-                                      >
-                                        2037
-                                      </option>
-                                      <option
-                                        value="2036"
-                                      >
-                                        2036
-                                      </option>
-                                      <option
-                                        value="2035"
-                                      >
-                                        2035
-                                      </option>
-                                      <option
-                                        value="2034"
-                                      >
-                                        2034
-                                      </option>
-                                      <option
-                                        value="2033"
-                                      >
-                                        2033
-                                      </option>
-                                      <option
-                                        value="2032"
-                                      >
-                                        2032
-                                      </option>
-                                      <option
-                                        value="2031"
-                                      >
-                                        2031
-                                      </option>
-                                      <option
-                                        value="2030"
-                                      >
-                                        2030
-                                      </option>
-                                      <option
-                                        value="2029"
-                                      >
-                                        2029
-                                      </option>
-                                      <option
-                                        value="2028"
-                                      >
-                                        2028
-                                      </option>
-                                      <option
-                                        value="2027"
-                                      >
-                                        2027
-                                      </option>
-                                      <option
-                                        value="2026"
-                                      >
-                                        2026
-                                      </option>
-                                      <option
-                                        value="2025"
-                                      >
-                                        2025
-                                      </option>
-                                      <option
-                                        value="2024"
-                                      >
-                                        2024
-                                      </option>
-                                    </select>
-                                    <svg
-                                      aria-hidden="true"
-                                      class="navds-select__chevron"
-                                      fill="none"
-                                      focusable="false"
-                                      height="1em"
-                                      role="img"
-                                      viewBox="0 0 24 24"
-                                      width="1em"
-                                      xmlns="http://www.w3.org/2000/svg"
-                                    >
-                                      <path
-                                        clip-rule="evenodd"
-                                        d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
-                                        fill="currentColor"
-                                        fill-rule="evenodd"
-                                      />
-                                    </svg>
-                                  </div>
-                                  <div
-                                    aria-live="polite"
-                                    aria-relevant="additions removals"
-                                    class="navds-form-field__error"
-                                    id="select-error-r4l"
-                                  />
-                                </div>
-                              </div>
-                              <button
-                                class="navds-date__caption-button navds-button navds-button--tertiary navds-button--medium navds-button--icon-only"
-                                type="button"
-                              >
-                                <span
-                                  class="navds-button__icon"
-                                >
-                                  <svg
-                                    aria-labelledby="title-r4n"
-                                    fill="none"
-                                    focusable="false"
-                                    height="1em"
-                                    role="img"
-                                    viewBox="0 0 24 24"
-                                    width="1em"
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <title
-                                      id="title-r4n"
-                                    >
-                                      Gå til neste måned
-                                    </title>
-                                    <path
-                                      d="M14.087 6.874a.752.752 0 0 0-.117 1.156l3.22 3.22H5a.75.75 0 0 0 0 1.5h12.19l-3.22 3.22a.75.75 0 0 0 1.06 1.06l4.5-4.5a.75.75 0 0 0 0-1.06l-4.5-4.5a.75.75 0 0 0-.943-.096"
-                                      fill="currentColor"
-                                    />
-                                  </svg>
-                                </span>
-                              </button>
-                            </div>
-                            <table
-                              aria-labelledby="react-day-picker-4"
-                              class="rdp-table"
-                              role="grid"
-                            >
-                              <thead
-                                aria-hidden="true"
-                                class="rdp-head"
-                              >
-                                <tr
-                                  class="rdp-head_row"
-                                >
-                                  <th
-                                    aria-label="mandag"
-                                    class="rdp-head_cell"
-                                    scope="col"
-                                  >
-                                    ma
-                                  </th>
-                                  <th
-                                    aria-label="tirsdag"
-                                    class="rdp-head_cell"
-                                    scope="col"
-                                  >
-                                    ti
-                                  </th>
-                                  <th
-                                    aria-label="onsdag"
-                                    class="rdp-head_cell"
-                                    scope="col"
-                                  >
-                                    on
-                                  </th>
-                                  <th
-                                    aria-label="torsdag"
-                                    class="rdp-head_cell"
-                                    scope="col"
-                                  >
-                                    to
-                                  </th>
-                                  <th
-                                    aria-label="fredag"
-                                    class="rdp-head_cell"
-                                    scope="col"
-                                  >
-                                    fr
-                                  </th>
-                                  <th
-                                    aria-label="lørdag"
-                                    class="rdp-head_cell"
-                                    scope="col"
-                                  >
-                                    lø
-                                  </th>
-                                  <th
-                                    aria-label="søndag"
-                                    class="rdp-head_cell"
-                                    scope="col"
-                                  >
-                                    sø
-                                  </th>
-                                </tr>
-                              </thead>
-                              <tbody
-                                class="rdp-tbody"
-                              >
-                                <tr
-                                  class="rdp-row"
-                                >
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="mandag 1"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day rdp-day_today"
-                                      name="day"
-                                      tabindex="0"
-                                      type="button"
-                                    >
-                                      1
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="tirsdag 2"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      2
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="onsdag 3"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      3
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="torsdag 4"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      4
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="fredag 5"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      5
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="lørdag 6"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      6
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="søndag 7"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      7
-                                    </button>
-                                  </td>
-                                </tr>
-                                <tr
-                                  class="rdp-row"
-                                >
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="mandag 8"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      8
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="tirsdag 9"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      9
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="onsdag 10"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      10
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="torsdag 11"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      11
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="fredag 12"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      12
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="lørdag 13"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      13
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="søndag 14"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      14
-                                    </button>
-                                  </td>
-                                </tr>
-                                <tr
-                                  class="rdp-row"
-                                >
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="mandag 15"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      15
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="tirsdag 16"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      16
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="onsdag 17"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      17
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="torsdag 18"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      18
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="fredag 19"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      19
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="lørdag 20"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      20
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="søndag 21"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      21
-                                    </button>
-                                  </td>
-                                </tr>
-                                <tr
-                                  class="rdp-row"
-                                >
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="mandag 22"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      22
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="tirsdag 23"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      23
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="onsdag 24"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      24
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="torsdag 25"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      25
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="fredag 26"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      26
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="lørdag 27"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      27
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="søndag 28"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      28
-                                    </button>
-                                  </td>
-                                </tr>
-                                <tr
-                                  class="rdp-row"
-                                >
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="mandag 29"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      29
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="tirsdag 30"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      30
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="onsdag 31"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      31
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-hidden="true"
-                                      aria-label="torsdag 1"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      1
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-hidden="true"
-                                      aria-label="fredag 2"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      2
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-hidden="true"
-                                      aria-label="lørdag 3"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      3
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-hidden="true"
-                                      aria-label="søndag 4"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      4
-                                    </button>
-                                  </td>
-                                </tr>
-                                <tr
-                                  class="rdp-row"
-                                >
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-hidden="true"
-                                      aria-label="mandag 5"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      5
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-hidden="true"
-                                      aria-label="tirsdag 6"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      6
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-hidden="true"
-                                      aria-label="onsdag 7"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      7
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-hidden="true"
-                                      aria-label="torsdag 8"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      8
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-hidden="true"
-                                      aria-label="fredag 9"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      9
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-hidden="true"
-                                      aria-label="lørdag 10"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      10
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-hidden="true"
-                                      aria-label="søndag 11"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      11
-                                    </button>
-                                  </td>
-                                </tr>
-                              </tbody>
-                            </table>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
                   </div>
-                </section>
-              </div>
-            </div>
-          </div>
-        </fieldset>
-        <fieldset
-          class="sc-blHHSb hqrzOP"
-        >
-          <div
-            id="arbeidsforhold[0].forventerEndretArbeidssituasjon.svar"
-          >
-            <fieldset
-              class="navds-radio-group navds-radio-group--medium navds-fieldset navds-fieldset--medium"
-            >
-              <legend
-                class="navds-fieldset__legend navds-label"
-              >
-                merOmSituasjonenDin.arbeidsforhold.forventerEndretArbeidssituasjon.svar
-              </legend>
-              <div
-                class="navds-radio-buttons"
-              >
-                <div
-                  class="radioBorder navds-radio navds-radio--medium"
-                >
-                  <input
-                    aria-labelledby="r4s"
-                    class="navds-radio__input"
-                    id="radio-r4r"
-                    name="arbeidsforhold[0].forventerEndretArbeidssituasjon.svar"
-                    type="radio"
-                    value="radiobuttons.ja"
-                  />
-                  <label
-                    class="navds-radio__label"
-                    for="radio-r4r"
-                  >
-                    <span
-                      class="navds-radio__content"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="navds-body-short navds-body-short--medium"
-                        id="r4s"
-                      >
-                        radiobuttons.ja
-                      </span>
-                    </span>
-                  </label>
-                </div>
-                <div
-                  class="radioBorder navds-radio navds-radio--medium"
-                >
-                  <input
-                    aria-labelledby="r4v"
-                    class="navds-radio__input"
-                    id="radio-r4u"
-                    name="arbeidsforhold[0].forventerEndretArbeidssituasjon.svar"
-                    type="radio"
-                    value="radiobuttons.nei"
-                  />
-                  <label
-                    class="navds-radio__label"
-                    for="radio-r4u"
-                  >
-                    <span
-                      class="navds-radio__content"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="navds-body-short navds-body-short--medium"
-                        id="r4v"
-                      >
-                        radiobuttons.nei
-                      </span>
-                    </span>
-                  </label>
                 </div>
               </div>
               <div
-                aria-live="polite"
-                aria-relevant="additions removals"
-                class="navds-fieldset__error"
-                id="fieldset-error-r4q"
-              />
+                class="navds-read-more navds-read-more--medium"
+              >
+                <button
+                  aria-expanded="false"
+                  class="navds-read-more__button navds-body-short"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="navds-read-more__expand-icon"
+                    fill="none"
+                    focusable="false"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 24 24"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                  <span>
+                    hvorforSpoerVi
+                  </span>
+                </button>
+                <div
+                  aria-hidden="true"
+                  class="navds-read-more__content navds-read-more__content--closed navds-body-long navds-body-long--medium"
+                >
+                  merOmSituasjonenDin.arbeidsforhold.sagtOppEllerRedusert.hvorfor
+                </div>
+              </div>
             </fieldset>
           </div>
-          <div
-            style="display: none;"
-          >
-            <div
-              class="sc-cHqXqK jvHoMc"
-            >
-              <div
-                class="width-50"
-              >
-                <div
-                  class="navds-form-field navds-form-field--medium"
-                >
-                  <label
-                    class="navds-form-field__label navds-label"
-                    for="arbeidsforhold[0].forventerEndretArbeidssituasjon.beskrivelse"
-                  >
-                    merOmSituasjonenDin.arbeidsforhold.forventerEndretArbeidssituasjon.beskrivelse
-                  </label>
-                  <div
-                    class="navds-form-field__description navds-body-short navds-body-short--medium"
-                    id="textarea-description-r51"
-                  >
-                    felles.ikkeSensitiveOpplysninger
-                  </div>
-                  <textarea
-                    aria-describedby="textarea-description-r51 r52"
-                    class="navds-textarea__input navds-body-short navds-body-short--medium"
-                    id="arbeidsforhold[0].forventerEndretArbeidssituasjon.beskrivelse"
-                    rows="3"
-                    style="--__ac-textarea-height: -4px; overflow: hidden;"
-                  />
-                  <textarea
-                    aria-hidden="true"
-                    class="navds-textarea__input navds-body-short navds-body-short--medium"
-                    readonly=""
-                    style="visibility: hidden; position: absolute; overflow: hidden; height: 0px; top: 0px; left: 0px; transform: translateZ(0);"
-                    tabindex="-1"
-                  />
-                  <span
-                    class="navds-sr-only"
-                    id="r52"
-                  >
-                    Tekstområde med plass til 200 tegn.
-                  </span>
-                  <p
-                    class="navds-textarea__counter navds-body-short navds-body-short--medium"
-                  >
-                    200 counterLeft
-                  </p>
-                  <div
-                    aria-live="polite"
-                    aria-relevant="additions removals"
-                    class="navds-form-field__error"
-                    id="textarea-error-r51"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="navds-read-more navds-read-more--medium"
-          >
+          <div>
             <button
-              aria-expanded="false"
-              class="navds-read-more__button navds-body-short"
+              class="navds-button navds-button--secondary navds-button--medium"
+              data-testid="legg-til-arbeidsforhold-knapp"
               type="button"
             >
-              <svg
-                aria-hidden="true"
-                class="navds-read-more__expand-icon"
-                fill="none"
-                focusable="false"
-                height="1em"
-                role="img"
-                viewBox="0 0 24 24"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
+              <span
+                class="navds-label"
               >
-                <path
-                  clip-rule="evenodd"
-                  d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
-                  fill="currentColor"
-                  fill-rule="evenodd"
-                />
-              </svg>
-              <span>
-                hvorforSpoerVi
+                + 
+                knapp.leggTilArbeidsforhold
               </span>
             </button>
-            <div
-              aria-hidden="true"
-              class="navds-read-more__content navds-read-more__content--closed navds-body-long navds-body-long--medium"
-            >
-              merOmSituasjonenDin.arbeidsforhold.sagtOppEllerRedusert.hvorfor
-            </div>
           </div>
-        </fieldset>
-        <button
-          class="navds-button navds-button--secondary navds-button--medium"
-          data-testid="legg-til-arbeidsforhold-knapp"
-          type="button"
-        >
-          <span
-            class="navds-label"
-          >
-            + 
-            knapp.leggTilArbeidsforhold
-          </span>
-        </button>
+        </div>
       </fieldset>
       <fieldset
         class="sc-blHHSb hqrzOP"
@@ -2182,319 +2194,331 @@ exports[`Mer om situasjonen din > Skal rendre selvstendig 1`] = `
             merOmSituasjonenDin.selvstendig.tittel
           </h1>
         </div>
-        <fieldset
-          class="sc-blHHSb hqrzOP"
+        <div
+          class="navds-stack navds-vstack navds-stack-gap navds-stack-direction"
+          style="--__ac-stack-gap-xs: var(--a-spacing-4); --__ac-stack-direction-xs: column;"
         >
-          <div>
-            <div
-              class="navds-form-field navds-form-field--medium"
-            >
-              <label
-                class="navds-form-field__label navds-label"
-                for="selvstendig.[0].beskrivelse"
-              >
-                merOmSituasjonenDin.selvstendig.hvaHeterNaeringen
-              </label>
-              <div
-                class="navds-form-field__description navds-body-short navds-body-short--medium"
-                id="textField-description-r5u"
-              >
-                merOmSituasjonenDin.selvstendig.hvaHeterNaeringen.beskrivelse
-              </div>
-              <input
-                aria-describedby="textField-description-r5u"
-                class="navds-text-field__input navds-body-short navds-body-short--medium"
-                id="selvstendig.[0].beskrivelse"
-                size="35"
-                type="text"
-                value=""
-              />
-              <div
-                aria-live="polite"
-                aria-relevant="additions removals"
-                class="navds-form-field__error"
-                id="textField-error-r5u"
-              />
-            </div>
-          </div>
           <div
-            class="sc-cHqXqK jvHoMc"
+            class="navds-r-p navds-box navds-box-bg navds-box-border-color navds-box-border-width"
+            style="--__ac-r-p-xs: var(--a-spacing-4); --__ac-box-background: var(--a-surface-selected); --__ac-box-border-color: var(--a-border-info); --__ac-box-border-width: 0px 0px 0px 4px;"
           >
-            <div
-              class="navds-form-field navds-form-field--medium"
+            <fieldset
+              class="sc-blHHSb hqrzOP"
             >
-              <label
-                class="navds-form-field__label navds-label"
-                for="selvstendig.[0].orgnr"
-              >
-                merOmSituasjonenDin.selvstendig.orgnr
-              </label>
-              <div
-                class="navds-form-field__description navds-body-short navds-body-short--medium"
-                id="textField-description-r5v"
-              >
-                merOmSituasjonenDin.selvstendig.orgnrplaceholder
-              </div>
-              <input
-                aria-describedby="textField-description-r5v"
-                class="navds-text-field__input navds-body-short navds-body-short--medium"
-                id="selvstendig.[0].orgnr"
-                size="25"
-                type="text"
-                value=""
-              />
-              <div
-                aria-live="polite"
-                aria-relevant="additions removals"
-                class="navds-form-field__error"
-                id="textField-error-r5v"
-              />
-            </div>
-          </div>
-        </fieldset>
-        <fieldset
-          class="sc-blHHSb hqrzOP"
-        >
-          <label
-            class="navds-label"
-          >
-            merOmSituasjonenDin.selvstendig.arbeidsmengde
-          </label>
-          <p
-            class="navds-body-short navds-body-short--medium navds-typo--color-subtle"
-          >
-            merOmSituasjonenDin.selvstendig.arbeidsmengde.beskrivelse
-          </p>
-          <div
-            class="sc-cHqXqK jvHoMc"
-          >
-            <div
-              class="sc-dpBQxM cXcjLZ"
-            >
-              <div
-                class="navds-form-field navds-form-field--medium"
-              >
-                <label
-                  class="navds-form-field__label navds-label"
-                  for="selvstendig.[0].arbeidsmengde.svar"
-                >
-                  merOmSituasjonenDin.selvstendig.arbeidsmengde.svar
-                </label>
-                <input
-                  class="navds-text-field__input navds-body-short navds-body-short--medium"
-                  id="selvstendig.[0].arbeidsmengde.svar"
-                  size="25"
-                  type="text"
-                  value=""
-                />
+              <div>
                 <div
-                  aria-live="polite"
-                  aria-relevant="additions removals"
-                  class="navds-form-field__error"
-                  id="textField-error-r60"
-                />
+                  class="navds-form-field navds-form-field--medium"
+                >
+                  <label
+                    class="navds-form-field__label navds-label"
+                    for="selvstendig.[0].beskrivelse"
+                  >
+                    merOmSituasjonenDin.selvstendig.hvaHeterNaeringen
+                  </label>
+                  <div
+                    class="navds-form-field__description navds-body-short navds-body-short--medium"
+                    id="textField-description-r5u"
+                  >
+                    merOmSituasjonenDin.selvstendig.hvaHeterNaeringen.beskrivelse
+                  </div>
+                  <input
+                    aria-describedby="textField-description-r5u"
+                    class="navds-text-field__input navds-body-short navds-body-short--medium"
+                    id="selvstendig.[0].beskrivelse"
+                    size="35"
+                    type="text"
+                    value=""
+                  />
+                  <div
+                    aria-live="polite"
+                    aria-relevant="additions removals"
+                    class="navds-form-field__error"
+                    id="textField-error-r5u"
+                  />
+                </div>
               </div>
               <div
-                class="sc-cEzcPc guivVO"
-                id="selvstendig.[0].arbeidsmengde.type"
+                class="sc-cHqXqK jvHoMc"
               >
                 <div
                   class="navds-form-field navds-form-field--medium"
                 >
                   <label
                     class="navds-form-field__label navds-label"
-                    for="select-r61"
+                    for="selvstendig.[0].orgnr"
                   >
-                    felles.velg.tittel
+                    merOmSituasjonenDin.selvstendig.orgnr
                   </label>
                   <div
-                    class="navds-select__container"
+                    class="navds-form-field__description navds-body-short navds-body-short--medium"
+                    id="textField-description-r5v"
                   >
-                    <select
-                      class="navds-select__input navds-body-short navds-body-short--medium"
-                      id="select-r61"
-                    >
-                      <option
-                        value=""
-                      >
-                        felles.velg
-                      </option>
-                      <option
-                        value="arbeidsmengde.prosent"
-                      >
-                        arbeidsmengde.prosent
-                      </option>
-                      <option
-                        value="arbeidsmengde.timer"
-                      >
-                        arbeidsmengde.timer
-                      </option>
-                    </select>
-                    <svg
-                      aria-hidden="true"
-                      class="navds-select__chevron"
-                      fill="none"
-                      focusable="false"
-                      height="1em"
-                      role="img"
-                      viewBox="0 0 24 24"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        clip-rule="evenodd"
-                        d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
-                        fill="currentColor"
-                        fill-rule="evenodd"
-                      />
-                    </svg>
+                    merOmSituasjonenDin.selvstendig.orgnrplaceholder
                   </div>
+                  <input
+                    aria-describedby="textField-description-r5v"
+                    class="navds-text-field__input navds-body-short navds-body-short--medium"
+                    id="selvstendig.[0].orgnr"
+                    size="25"
+                    type="text"
+                    value=""
+                  />
                   <div
                     aria-live="polite"
                     aria-relevant="additions removals"
                     class="navds-form-field__error"
-                    id="select-error-r61"
+                    id="textField-error-r5v"
                   />
+                </div>
+              </div>
+            </fieldset>
+            <fieldset
+              class="sc-blHHSb hqrzOP"
+            >
+              <label
+                class="navds-label"
+              >
+                merOmSituasjonenDin.selvstendig.arbeidsmengde
+              </label>
+              <p
+                class="navds-body-short navds-body-short--medium navds-typo--color-subtle"
+              >
+                merOmSituasjonenDin.selvstendig.arbeidsmengde.beskrivelse
+              </p>
+              <div
+                class="sc-cHqXqK jvHoMc"
+              >
+                <div
+                  class="sc-dpBQxM cXcjLZ"
+                >
+                  <div
+                    class="navds-form-field navds-form-field--medium"
+                  >
+                    <label
+                      class="navds-form-field__label navds-label"
+                      for="selvstendig.[0].arbeidsmengde.svar"
+                    >
+                      merOmSituasjonenDin.selvstendig.arbeidsmengde.svar
+                    </label>
+                    <input
+                      class="navds-text-field__input navds-body-short navds-body-short--medium"
+                      id="selvstendig.[0].arbeidsmengde.svar"
+                      size="25"
+                      type="text"
+                      value=""
+                    />
+                    <div
+                      aria-live="polite"
+                      aria-relevant="additions removals"
+                      class="navds-form-field__error"
+                      id="textField-error-r60"
+                    />
+                  </div>
+                  <div
+                    class="sc-cEzcPc guivVO"
+                    id="selvstendig.[0].arbeidsmengde.type"
+                  >
+                    <div
+                      class="navds-form-field navds-form-field--medium"
+                    >
+                      <label
+                        class="navds-form-field__label navds-label"
+                        for="select-r61"
+                      >
+                        felles.velg.tittel
+                      </label>
+                      <div
+                        class="navds-select__container"
+                      >
+                        <select
+                          class="navds-select__input navds-body-short navds-body-short--medium"
+                          id="select-r61"
+                        >
+                          <option
+                            value=""
+                          >
+                            felles.velg
+                          </option>
+                          <option
+                            value="arbeidsmengde.prosent"
+                          >
+                            arbeidsmengde.prosent
+                          </option>
+                          <option
+                            value="arbeidsmengde.timer"
+                          >
+                            arbeidsmengde.timer
+                          </option>
+                        </select>
+                        <svg
+                          aria-hidden="true"
+                          class="navds-select__chevron"
+                          fill="none"
+                          focusable="false"
+                          height="1em"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                      <div
+                        aria-live="polite"
+                        aria-relevant="additions removals"
+                        class="navds-form-field__error"
+                        id="select-error-r61"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </fieldset>
+            <div
+              class="sc-cHqXqK jvHoMc"
+            >
+              <div
+                id="selvstendig.[0].forventerEndretArbeidssituasjon.svar"
+              >
+                <fieldset
+                  class="navds-radio-group navds-radio-group--medium navds-fieldset navds-fieldset--medium"
+                >
+                  <legend
+                    class="navds-fieldset__legend navds-label"
+                  >
+                    merOmSituasjonenDin.selvstendig.forventerEndretArbeidssituasjon.svar
+                  </legend>
+                  <div
+                    class="navds-radio-buttons"
+                  >
+                    <div
+                      class="radioBorder navds-radio navds-radio--medium"
+                    >
+                      <input
+                        aria-labelledby="r66"
+                        class="navds-radio__input"
+                        id="radio-r65"
+                        name="selvstendig.[0].forventerEndretArbeidssituasjon.svar"
+                        type="radio"
+                        value="radiobuttons.ja"
+                      />
+                      <label
+                        class="navds-radio__label"
+                        for="radio-r65"
+                      >
+                        <span
+                          class="navds-radio__content"
+                        >
+                          <span
+                            aria-hidden="true"
+                            class="navds-body-short navds-body-short--medium"
+                            id="r66"
+                          >
+                            radiobuttons.ja
+                          </span>
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      class="radioBorder navds-radio navds-radio--medium"
+                    >
+                      <input
+                        aria-labelledby="r69"
+                        class="navds-radio__input"
+                        id="radio-r68"
+                        name="selvstendig.[0].forventerEndretArbeidssituasjon.svar"
+                        type="radio"
+                        value="radiobuttons.nei"
+                      />
+                      <label
+                        class="navds-radio__label"
+                        for="radio-r68"
+                      >
+                        <span
+                          class="navds-radio__content"
+                        >
+                          <span
+                            aria-hidden="true"
+                            class="navds-body-short navds-body-short--medium"
+                            id="r69"
+                          >
+                            radiobuttons.nei
+                          </span>
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                  <div
+                    aria-live="polite"
+                    aria-relevant="additions removals"
+                    class="navds-fieldset__error"
+                    id="fieldset-error-r64"
+                  />
+                </fieldset>
+              </div>
+            </div>
+            <div
+              class="sc-cHqXqK jvHoMc"
+            >
+              <div
+                class="navds-read-more navds-read-more--medium"
+              >
+                <button
+                  aria-expanded="false"
+                  class="navds-read-more__button navds-body-short"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="navds-read-more__expand-icon"
+                    fill="none"
+                    focusable="false"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 24 24"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                  <span>
+                    hvorforSpoerVi
+                  </span>
+                </button>
+                <div
+                  aria-hidden="true"
+                  class="navds-read-more__content navds-read-more__content--closed navds-body-long navds-body-long--medium"
+                >
+                  merOmSituasjonenDin.selvstendig.grunnTilSpoersmål.hvorfor
                 </div>
               </div>
             </div>
           </div>
-        </fieldset>
-        <div
-          class="sc-cHqXqK jvHoMc"
-        >
-          <div
-            id="selvstendig.[0].forventerEndretArbeidssituasjon.svar"
-          >
-            <fieldset
-              class="navds-radio-group navds-radio-group--medium navds-fieldset navds-fieldset--medium"
-            >
-              <legend
-                class="navds-fieldset__legend navds-label"
-              >
-                merOmSituasjonenDin.selvstendig.forventerEndretArbeidssituasjon.svar
-              </legend>
-              <div
-                class="navds-radio-buttons"
-              >
-                <div
-                  class="radioBorder navds-radio navds-radio--medium"
-                >
-                  <input
-                    aria-labelledby="r66"
-                    class="navds-radio__input"
-                    id="radio-r65"
-                    name="selvstendig.[0].forventerEndretArbeidssituasjon.svar"
-                    type="radio"
-                    value="radiobuttons.ja"
-                  />
-                  <label
-                    class="navds-radio__label"
-                    for="radio-r65"
-                  >
-                    <span
-                      class="navds-radio__content"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="navds-body-short navds-body-short--medium"
-                        id="r66"
-                      >
-                        radiobuttons.ja
-                      </span>
-                    </span>
-                  </label>
-                </div>
-                <div
-                  class="radioBorder navds-radio navds-radio--medium"
-                >
-                  <input
-                    aria-labelledby="r69"
-                    class="navds-radio__input"
-                    id="radio-r68"
-                    name="selvstendig.[0].forventerEndretArbeidssituasjon.svar"
-                    type="radio"
-                    value="radiobuttons.nei"
-                  />
-                  <label
-                    class="navds-radio__label"
-                    for="radio-r68"
-                  >
-                    <span
-                      class="navds-radio__content"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="navds-body-short navds-body-short--medium"
-                        id="r69"
-                      >
-                        radiobuttons.nei
-                      </span>
-                    </span>
-                  </label>
-                </div>
-              </div>
-              <div
-                aria-live="polite"
-                aria-relevant="additions removals"
-                class="navds-fieldset__error"
-                id="fieldset-error-r64"
-              />
-            </fieldset>
-          </div>
-        </div>
-        <div
-          class="sc-cHqXqK jvHoMc"
-        >
-          <div
-            class="navds-read-more navds-read-more--medium"
-          >
+          <div>
             <button
-              aria-expanded="false"
-              class="navds-read-more__button navds-body-short"
+              class="navds-button navds-button--secondary navds-button--medium"
               type="button"
             >
-              <svg
-                aria-hidden="true"
-                class="navds-read-more__expand-icon"
-                fill="none"
-                focusable="false"
-                height="1em"
-                role="img"
-                viewBox="0 0 24 24"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
+              <span
+                class="navds-label"
               >
-                <path
-                  clip-rule="evenodd"
-                  d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
-                  fill="currentColor"
-                  fill-rule="evenodd"
-                />
-              </svg>
-              <span>
-                hvorforSpoerVi
+                + 
+                knapp.leggTilNaeringer
               </span>
             </button>
-            <div
-              aria-hidden="true"
-              class="navds-read-more__content navds-read-more__content--closed navds-body-long navds-body-long--medium"
-            >
-              merOmSituasjonenDin.selvstendig.grunnTilSpoersmål.hvorfor
-            </div>
           </div>
         </div>
-        <button
-          class="navds-button navds-button--secondary navds-button--medium"
-          type="button"
-        >
-          <span
-            class="navds-label"
-          >
-            + 
-            knapp.leggTilNaeringer
-          </span>
-        </button>
       </fieldset>
     </div>
     <fieldset
@@ -3524,1698 +3548,1710 @@ exports[`Mer om situasjonen din > Snapshot 1`] = `
           </h1>
         </div>
         <div
-          class="sc-cHqXqK jvHoMc"
-        >
-          <div>
-            <div
-              class="navds-form-field navds-form-field--medium"
-            >
-              <label
-                class="navds-form-field__label navds-label"
-                for="arbeidsforhold[0].arbeidsgiver"
-              >
-                merOmSituasjonenDin.arbeidsforhold.arbeidsgiver
-              </label>
-              <input
-                class="navds-text-field__input navds-body-short navds-body-short--medium"
-                id="arbeidsforhold[0].arbeidsgiver"
-                size="35"
-                type="text"
-                value="Potetskreller AS"
-              />
-              <div
-                aria-live="polite"
-                aria-relevant="additions removals"
-                class="navds-form-field__error"
-                id="textField-error-rn"
-              />
-            </div>
-          </div>
-        </div>
-        <div
-          class="sc-cHqXqK jvHoMc"
+          class="navds-stack navds-vstack navds-stack-gap navds-stack-direction"
+          style="--__ac-stack-gap-xs: var(--a-spacing-4); --__ac-stack-direction-xs: column;"
         >
           <div
-            id="arbeidsforhold[0].ansettelsesforhold"
-          >
-            <fieldset
-              class="navds-radio-group navds-radio-group--medium navds-fieldset navds-fieldset--medium"
-            >
-              <legend
-                class="navds-fieldset__legend navds-label"
-              >
-                merOmSituasjonenDin.arbeidsforhold.ansettelsesforhold
-              </legend>
-              <div
-                class="navds-radio-buttons"
-              >
-                <div
-                  class="radioBorder navds-radio navds-radio--medium"
-                >
-                  <input
-                    aria-labelledby="rr"
-                    class="navds-radio__input"
-                    id="radio-rq"
-                    name="arbeidsforhold[0].ansettelsesforhold"
-                    type="radio"
-                    value="stillingType.fast"
-                  />
-                  <label
-                    class="navds-radio__label"
-                    for="radio-rq"
-                  >
-                    <span
-                      class="navds-radio__content"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="navds-body-short navds-body-short--medium"
-                        id="rr"
-                      >
-                        stillingType.fast
-                      </span>
-                    </span>
-                  </label>
-                </div>
-                <div
-                  class="radioBorder navds-radio navds-radio--medium"
-                >
-                  <input
-                    aria-labelledby="ru"
-                    checked=""
-                    class="navds-radio__input"
-                    id="radio-rt"
-                    name="arbeidsforhold[0].ansettelsesforhold"
-                    type="radio"
-                    value="stillingType.midlertidig"
-                  />
-                  <label
-                    class="navds-radio__label"
-                    for="radio-rt"
-                  >
-                    <span
-                      class="navds-radio__content"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="navds-body-short navds-body-short--medium"
-                        id="ru"
-                      >
-                        stillingType.midlertidig
-                      </span>
-                    </span>
-                  </label>
-                </div>
-                <div
-                  class="radioBorder navds-radio navds-radio--medium"
-                >
-                  <input
-                    aria-labelledby="r11"
-                    class="navds-radio__input"
-                    id="radio-r10"
-                    name="arbeidsforhold[0].ansettelsesforhold"
-                    type="radio"
-                    value="stillingType.tilkallingsvikar"
-                  />
-                  <label
-                    class="navds-radio__label"
-                    for="radio-r10"
-                  >
-                    <span
-                      class="navds-radio__content"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="navds-body-short navds-body-short--medium"
-                        id="r11"
-                      >
-                        stillingType.tilkallingsvikar
-                      </span>
-                    </span>
-                  </label>
-                </div>
-              </div>
-              <div
-                aria-live="polite"
-                aria-relevant="additions removals"
-                class="navds-fieldset__error"
-                id="fieldset-error-rp"
-              />
-            </fieldset>
-          </div>
-        </div>
-        <fieldset
-          class="sc-blHHSb hqrzOP"
-        >
-          <div
-            style="display: none;"
+            class="navds-r-p navds-box navds-box-bg navds-box-border-color navds-box-border-width"
+            style="--__ac-r-p-xs: var(--a-spacing-4); --__ac-box-background: var(--a-surface-selected); --__ac-box-border-color: var(--a-border-info); --__ac-box-border-width: 0px 0px 0px 4px;"
           >
             <div
               class="sc-cHqXqK jvHoMc"
             >
-              <div
-                class="sc-cHqXqK jvHoMc"
-              >
-                <h1
-                  class="navds-heading navds-heading--small"
-                >
-                  merOmSituasjonenDin.arbeidsforhold.ansettelsesforhold.fast.tittel
-                </h1>
-                <p
-                  class="navds-body-short navds-body-short--medium"
-                >
-                  merOmSituasjonenDin.arbeidsforhold.ansettelsesforhold.fast.beskrivelse
-                </p>
-              </div>
-              <div
-                class="navds-form-field navds-form-field--medium"
-              >
-                <label
-                  class="navds-form-field__label navds-label"
-                  for="arbeidsforhold[0].arbeidsmengde.svar"
-                >
-                  merOmSituasjonenDin.arbeidsforhold.arbeidsmengde.svar.fast
-                </label>
-                <input
-                  aria-hidden="true"
-                  class="navds-text-field__input navds-body-short navds-body-short--medium"
-                  id="arbeidsforhold[0].arbeidsmengde.svar"
-                  size="10"
-                  type="text"
-                  value=""
-                />
-                <div
-                  aria-live="polite"
-                  aria-relevant="additions removals"
-                  class="navds-form-field__error"
-                  id="textField-error-r13"
-                />
-              </div>
-            </div>
-          </div>
-          <div
-            style="display: block;"
-          >
-            <div
-              class="sc-cHqXqK jvHoMc"
-            >
-              <div
-                class="sc-cHqXqK jvHoMc"
-              >
-                <h1
-                  class="navds-heading navds-heading--small"
-                >
-                  merOmSituasjonenDin.arbeidsforhold.ansettelsesforhold.fast.tittel
-                </h1>
-                <p
-                  class="navds-body-short navds-body-short--medium"
-                >
-                  merOmSituasjonenDin.arbeidsforhold.ansettelsesforhold.midlertidig.beskrivelse
-                </p>
-              </div>
-              <div
-                class="sc-dpBQxM cXcjLZ"
-              >
+              <div>
                 <div
                   class="navds-form-field navds-form-field--medium"
                 >
                   <label
                     class="navds-form-field__label navds-label"
-                    for="arbeidsforhold[0].arbeidsmengde.svar"
+                    for="arbeidsforhold[0].arbeidsgiver"
                   >
-                    merOmSituasjonenDin.arbeidsforhold.arbeidsmengde.svar
+                    merOmSituasjonenDin.arbeidsforhold.arbeidsgiver
                   </label>
                   <input
-                    aria-hidden="false"
                     class="navds-text-field__input navds-body-short navds-body-short--medium"
-                    id="arbeidsforhold[0].arbeidsmengde.svar"
-                    size="25"
+                    id="arbeidsforhold[0].arbeidsgiver"
+                    size="35"
                     type="text"
-                    value=""
+                    value="Potetskreller AS"
                   />
                   <div
                     aria-live="polite"
                     aria-relevant="additions removals"
                     class="navds-form-field__error"
-                    id="textField-error-r14"
+                    id="textField-error-rn"
                   />
                 </div>
-                <div
-                  class="sc-cEzcPc guivVO"
-                  id="arbeidsforhold[0].arbeidsmengde.type"
+              </div>
+            </div>
+            <div
+              class="sc-cHqXqK jvHoMc"
+            >
+              <div
+                id="arbeidsforhold[0].ansettelsesforhold"
+              >
+                <fieldset
+                  class="navds-radio-group navds-radio-group--medium navds-fieldset navds-fieldset--medium"
                 >
+                  <legend
+                    class="navds-fieldset__legend navds-label"
+                  >
+                    merOmSituasjonenDin.arbeidsforhold.ansettelsesforhold
+                  </legend>
+                  <div
+                    class="navds-radio-buttons"
+                  >
+                    <div
+                      class="radioBorder navds-radio navds-radio--medium"
+                    >
+                      <input
+                        aria-labelledby="rr"
+                        class="navds-radio__input"
+                        id="radio-rq"
+                        name="arbeidsforhold[0].ansettelsesforhold"
+                        type="radio"
+                        value="stillingType.fast"
+                      />
+                      <label
+                        class="navds-radio__label"
+                        for="radio-rq"
+                      >
+                        <span
+                          class="navds-radio__content"
+                        >
+                          <span
+                            aria-hidden="true"
+                            class="navds-body-short navds-body-short--medium"
+                            id="rr"
+                          >
+                            stillingType.fast
+                          </span>
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      class="radioBorder navds-radio navds-radio--medium"
+                    >
+                      <input
+                        aria-labelledby="ru"
+                        checked=""
+                        class="navds-radio__input"
+                        id="radio-rt"
+                        name="arbeidsforhold[0].ansettelsesforhold"
+                        type="radio"
+                        value="stillingType.midlertidig"
+                      />
+                      <label
+                        class="navds-radio__label"
+                        for="radio-rt"
+                      >
+                        <span
+                          class="navds-radio__content"
+                        >
+                          <span
+                            aria-hidden="true"
+                            class="navds-body-short navds-body-short--medium"
+                            id="ru"
+                          >
+                            stillingType.midlertidig
+                          </span>
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      class="radioBorder navds-radio navds-radio--medium"
+                    >
+                      <input
+                        aria-labelledby="r11"
+                        class="navds-radio__input"
+                        id="radio-r10"
+                        name="arbeidsforhold[0].ansettelsesforhold"
+                        type="radio"
+                        value="stillingType.tilkallingsvikar"
+                      />
+                      <label
+                        class="navds-radio__label"
+                        for="radio-r10"
+                      >
+                        <span
+                          class="navds-radio__content"
+                        >
+                          <span
+                            aria-hidden="true"
+                            class="navds-body-short navds-body-short--medium"
+                            id="r11"
+                          >
+                            stillingType.tilkallingsvikar
+                          </span>
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                  <div
+                    aria-live="polite"
+                    aria-relevant="additions removals"
+                    class="navds-fieldset__error"
+                    id="fieldset-error-rp"
+                  />
+                </fieldset>
+              </div>
+            </div>
+            <fieldset
+              class="sc-blHHSb hqrzOP"
+            >
+              <div
+                style="display: none;"
+              >
+                <div
+                  class="sc-cHqXqK jvHoMc"
+                >
+                  <div
+                    class="sc-cHqXqK jvHoMc"
+                  >
+                    <h1
+                      class="navds-heading navds-heading--small"
+                    >
+                      merOmSituasjonenDin.arbeidsforhold.ansettelsesforhold.fast.tittel
+                    </h1>
+                    <p
+                      class="navds-body-short navds-body-short--medium"
+                    >
+                      merOmSituasjonenDin.arbeidsforhold.ansettelsesforhold.fast.beskrivelse
+                    </p>
+                  </div>
                   <div
                     class="navds-form-field navds-form-field--medium"
                   >
                     <label
                       class="navds-form-field__label navds-label"
-                      for="select-r15"
+                      for="arbeidsforhold[0].arbeidsmengde.svar"
                     >
-                      felles.velg.tittel
+                      merOmSituasjonenDin.arbeidsforhold.arbeidsmengde.svar.fast
                     </label>
-                    <div
-                      class="navds-select__container"
-                    >
-                      <select
-                        aria-hidden="false"
-                        class="navds-select__input navds-body-short navds-body-short--medium"
-                        id="select-r15"
-                      >
-                        <option
-                          value=""
-                        >
-                          felles.velg
-                        </option>
-                        <option
-                          value="arbeidsmengde.prosent"
-                        >
-                          arbeidsmengde.prosent
-                        </option>
-                        <option
-                          value="arbeidsmengde.timer"
-                        >
-                          arbeidsmengde.timer
-                        </option>
-                      </select>
-                      <svg
-                        aria-hidden="true"
-                        class="navds-select__chevron"
-                        fill="none"
-                        focusable="false"
-                        height="1em"
-                        role="img"
-                        viewBox="0 0 24 24"
-                        width="1em"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          clip-rule="evenodd"
-                          d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
-                          fill="currentColor"
-                          fill-rule="evenodd"
-                        />
-                      </svg>
-                    </div>
+                    <input
+                      aria-hidden="true"
+                      class="navds-text-field__input navds-body-short navds-body-short--medium"
+                      id="arbeidsforhold[0].arbeidsmengde.svar"
+                      size="10"
+                      type="text"
+                      value=""
+                    />
                     <div
                       aria-live="polite"
                       aria-relevant="additions removals"
                       class="navds-form-field__error"
-                      id="select-error-r15"
+                      id="textField-error-r13"
                     />
                   </div>
                 </div>
               </div>
               <div
-                class="sc-cHqXqK jvHoMc"
+                style="display: block;"
               >
                 <div
-                  id="arbeidsforhold[0].midlertidig.svar"
-                >
-                  <fieldset
-                    class="navds-radio-group navds-radio-group--medium navds-fieldset navds-fieldset--medium"
-                  >
-                    <legend
-                      class="navds-fieldset__legend navds-label"
-                    >
-                      merOmSituasjonenDin.arbeidsforhold.midlertidig.svar
-                    </legend>
-                    <div
-                      class="navds-radio-buttons"
-                    >
-                      <div
-                        class="radioBorder navds-radio navds-radio--medium"
-                      >
-                        <input
-                          aria-labelledby="r1a"
-                          class="navds-radio__input"
-                          id="radio-r19"
-                          name="arbeidsforhold[0].midlertidig.svar"
-                          type="radio"
-                          value="radiobuttons.ja"
-                        />
-                        <label
-                          class="navds-radio__label"
-                          for="radio-r19"
-                        >
-                          <span
-                            class="navds-radio__content"
-                          >
-                            <span
-                              aria-hidden="true"
-                              class="navds-body-short navds-body-short--medium"
-                              id="r1a"
-                            >
-                              radiobuttons.ja
-                            </span>
-                          </span>
-                        </label>
-                      </div>
-                      <div
-                        class="radioBorder navds-radio navds-radio--medium"
-                      >
-                        <input
-                          aria-labelledby="r1d"
-                          class="navds-radio__input"
-                          id="radio-r1c"
-                          name="arbeidsforhold[0].midlertidig.svar"
-                          type="radio"
-                          value="radiobuttons.nei"
-                        />
-                        <label
-                          class="navds-radio__label"
-                          for="radio-r1c"
-                        >
-                          <span
-                            class="navds-radio__content"
-                          >
-                            <span
-                              aria-hidden="true"
-                              class="navds-body-short navds-body-short--medium"
-                              id="r1d"
-                            >
-                              radiobuttons.nei
-                            </span>
-                          </span>
-                        </label>
-                      </div>
-                    </div>
-                    <div
-                      aria-live="polite"
-                      aria-relevant="additions removals"
-                      class="navds-fieldset__error"
-                      id="fieldset-error-r18"
-                    />
-                  </fieldset>
-                </div>
-              </div>
-              <div
-                style="display: none;"
-              >
-                <section
-                  class="sc-jtQUzJ cfiJNq"
+                  class="sc-cHqXqK jvHoMc"
                 >
                   <div
-                    class="navds-date__wrapper"
+                    class="sc-cHqXqK jvHoMc"
+                  >
+                    <h1
+                      class="navds-heading navds-heading--small"
+                    >
+                      merOmSituasjonenDin.arbeidsforhold.ansettelsesforhold.fast.tittel
+                    </h1>
+                    <p
+                      class="navds-body-short navds-body-short--medium"
+                    >
+                      merOmSituasjonenDin.arbeidsforhold.ansettelsesforhold.midlertidig.beskrivelse
+                    </p>
+                  </div>
+                  <div
+                    class="sc-dpBQxM cXcjLZ"
                   >
                     <div
-                      class="navds-form-field navds-form-field--medium navds-date__field"
+                      class="navds-form-field navds-form-field--medium"
                     >
                       <label
                         class="navds-form-field__label navds-label"
-                        for="arbeidsforhold[0].midlertidig.sluttdatoVelger"
+                        for="arbeidsforhold[0].arbeidsmengde.svar"
                       >
-                        merOmSituasjonenDin.arbeidsforhold.midlertidig.sluttdatoVelger (felles.valgfri)
+                        merOmSituasjonenDin.arbeidsforhold.arbeidsmengde.svar
                       </label>
+                      <input
+                        aria-hidden="false"
+                        class="navds-text-field__input navds-body-short navds-body-short--medium"
+                        id="arbeidsforhold[0].arbeidsmengde.svar"
+                        size="25"
+                        type="text"
+                        value=""
+                      />
                       <div
-                        class="navds-form-field__description navds-body-short navds-body-short--medium"
-                        id="datepicker-input-description-r1g"
-                      >
-                        felles.oppgiDato felles.datoformat
-                      </div>
+                        aria-live="polite"
+                        aria-relevant="additions removals"
+                        class="navds-form-field__error"
+                        id="textField-error-r14"
+                      />
+                    </div>
+                    <div
+                      class="sc-cEzcPc guivVO"
+                      id="arbeidsforhold[0].arbeidsmengde.type"
+                    >
                       <div
-                        class="navds-date__field-wrapper"
+                        class="navds-form-field navds-form-field--medium"
                       >
-                        <input
-                          aria-describedby="datepicker-input-description-r1g"
-                          autocomplete="off"
-                          class="navds-date__field-input navds-text-field__input navds-body-short navds-body-short--medium"
-                          id="arbeidsforhold[0].midlertidig.sluttdatoVelger"
-                          size="11"
-                          value=""
-                        />
-                        <button
-                          class="navds-date__field-button"
-                          tabindex="0"
-                          type="button"
+                        <label
+                          class="navds-form-field__label navds-label"
+                          for="select-r15"
                         >
+                          felles.velg.tittel
+                        </label>
+                        <div
+                          class="navds-select__container"
+                        >
+                          <select
+                            aria-hidden="false"
+                            class="navds-select__input navds-body-short navds-body-short--medium"
+                            id="select-r15"
+                          >
+                            <option
+                              value=""
+                            >
+                              felles.velg
+                            </option>
+                            <option
+                              value="arbeidsmengde.prosent"
+                            >
+                              arbeidsmengde.prosent
+                            </option>
+                            <option
+                              value="arbeidsmengde.timer"
+                            >
+                              arbeidsmengde.timer
+                            </option>
+                          </select>
                           <svg
-                            aria-labelledby="title-r1h"
+                            aria-hidden="true"
+                            class="navds-select__chevron"
                             fill="none"
                             focusable="false"
                             height="1em"
-                            pointer-events="none"
                             role="img"
                             viewBox="0 0 24 24"
                             width="1em"
                             xmlns="http://www.w3.org/2000/svg"
                           >
-                            <title
-                              id="title-r1h"
-                            >
-                              Åpne datovelger
-                            </title>
                             <path
                               clip-rule="evenodd"
-                              d="M9 2.25a.75.75 0 0 1 .75.75v1.25h4.5V3a.75.75 0 0 1 1.5 0v1.25h3.75c.69 0 1.25.56 1.25 1.25v13c0 .69-.56 1.25-1.25 1.25h-15c-.69 0-1.25-.56-1.25-1.25v-13c0-.69.56-1.25 1.25-1.25h3.75V3A.75.75 0 0 1 9 2.25M15.75 7a.75.75 0 0 1-1.5 0V5.75h-4.5V7a.75.75 0 0 1-1.5 0V5.75h-3.5v3.5h14.5v-3.5h-3.5zm-11 11.25v-7.5h14.5v7.5zm2-5.25a.75.75 0 0 1 .75-.75h1a.75.75 0 0 1 0 1.5h-1a.75.75 0 0 1-.75-.75m4 0a.75.75 0 0 1 .75-.75h1a.75.75 0 0 1 0 1.5h-1a.75.75 0 0 1-.75-.75m4.75-.75a.75.75 0 0 0 0 1.5h1a.75.75 0 0 0 0-1.5zM10.75 16a.75.75 0 0 1 .75-.75h1a.75.75 0 0 1 0 1.5h-1a.75.75 0 0 1-.75-.75m4.75-.75a.75.75 0 0 0 0 1.5h1a.75.75 0 0 0 0-1.5zM6.75 16a.75.75 0 0 1 .75-.75h1a.75.75 0 0 1 0 1.5h-1a.75.75 0 0 1-.75-.75"
+                              d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
                               fill="currentColor"
                               fill-rule="evenodd"
                             />
                           </svg>
-                        </button>
+                        </div>
+                        <div
+                          aria-live="polite"
+                          aria-relevant="additions removals"
+                          class="navds-form-field__error"
+                          id="select-error-r15"
+                        />
                       </div>
+                    </div>
+                  </div>
+                  <div
+                    class="sc-cHqXqK jvHoMc"
+                  >
+                    <div
+                      id="arbeidsforhold[0].midlertidig.svar"
+                    >
+                      <fieldset
+                        class="navds-radio-group navds-radio-group--medium navds-fieldset navds-fieldset--medium"
+                      >
+                        <legend
+                          class="navds-fieldset__legend navds-label"
+                        >
+                          merOmSituasjonenDin.arbeidsforhold.midlertidig.svar
+                        </legend>
+                        <div
+                          class="navds-radio-buttons"
+                        >
+                          <div
+                            class="radioBorder navds-radio navds-radio--medium"
+                          >
+                            <input
+                              aria-labelledby="r1a"
+                              class="navds-radio__input"
+                              id="radio-r19"
+                              name="arbeidsforhold[0].midlertidig.svar"
+                              type="radio"
+                              value="radiobuttons.ja"
+                            />
+                            <label
+                              class="navds-radio__label"
+                              for="radio-r19"
+                            >
+                              <span
+                                class="navds-radio__content"
+                              >
+                                <span
+                                  aria-hidden="true"
+                                  class="navds-body-short navds-body-short--medium"
+                                  id="r1a"
+                                >
+                                  radiobuttons.ja
+                                </span>
+                              </span>
+                            </label>
+                          </div>
+                          <div
+                            class="radioBorder navds-radio navds-radio--medium"
+                          >
+                            <input
+                              aria-labelledby="r1d"
+                              class="navds-radio__input"
+                              id="radio-r1c"
+                              name="arbeidsforhold[0].midlertidig.svar"
+                              type="radio"
+                              value="radiobuttons.nei"
+                            />
+                            <label
+                              class="navds-radio__label"
+                              for="radio-r1c"
+                            >
+                              <span
+                                class="navds-radio__content"
+                              >
+                                <span
+                                  aria-hidden="true"
+                                  class="navds-body-short navds-body-short--medium"
+                                  id="r1d"
+                                >
+                                  radiobuttons.nei
+                                </span>
+                              </span>
+                            </label>
+                          </div>
+                        </div>
+                        <div
+                          aria-live="polite"
+                          aria-relevant="additions removals"
+                          class="navds-fieldset__error"
+                          id="fieldset-error-r18"
+                        />
+                      </fieldset>
+                    </div>
+                  </div>
+                  <div
+                    style="display: none;"
+                  >
+                    <section
+                      class="sc-jtQUzJ cfiJNq"
+                    >
+                      <div
+                        class="navds-date__wrapper"
+                      >
+                        <div
+                          class="navds-form-field navds-form-field--medium navds-date__field"
+                        >
+                          <label
+                            class="navds-form-field__label navds-label"
+                            for="arbeidsforhold[0].midlertidig.sluttdatoVelger"
+                          >
+                            merOmSituasjonenDin.arbeidsforhold.midlertidig.sluttdatoVelger (felles.valgfri)
+                          </label>
+                          <div
+                            class="navds-form-field__description navds-body-short navds-body-short--medium"
+                            id="datepicker-input-description-r1g"
+                          >
+                            felles.oppgiDato felles.datoformat
+                          </div>
+                          <div
+                            class="navds-date__field-wrapper"
+                          >
+                            <input
+                              aria-describedby="datepicker-input-description-r1g"
+                              autocomplete="off"
+                              class="navds-date__field-input navds-text-field__input navds-body-short navds-body-short--medium"
+                              id="arbeidsforhold[0].midlertidig.sluttdatoVelger"
+                              size="11"
+                              value=""
+                            />
+                            <button
+                              class="navds-date__field-button"
+                              tabindex="0"
+                              type="button"
+                            >
+                              <svg
+                                aria-labelledby="title-r1h"
+                                fill="none"
+                                focusable="false"
+                                height="1em"
+                                pointer-events="none"
+                                role="img"
+                                viewBox="0 0 24 24"
+                                width="1em"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <title
+                                  id="title-r1h"
+                                >
+                                  Åpne datovelger
+                                </title>
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M9 2.25a.75.75 0 0 1 .75.75v1.25h4.5V3a.75.75 0 0 1 1.5 0v1.25h3.75c.69 0 1.25.56 1.25 1.25v13c0 .69-.56 1.25-1.25 1.25h-15c-.69 0-1.25-.56-1.25-1.25v-13c0-.69.56-1.25 1.25-1.25h3.75V3A.75.75 0 0 1 9 2.25M15.75 7a.75.75 0 0 1-1.5 0V5.75h-4.5V7a.75.75 0 0 1-1.5 0V5.75h-3.5v3.5h14.5v-3.5h-3.5zm-11 11.25v-7.5h14.5v7.5zm2-5.25a.75.75 0 0 1 .75-.75h1a.75.75 0 0 1 0 1.5h-1a.75.75 0 0 1-.75-.75m4 0a.75.75 0 0 1 .75-.75h1a.75.75 0 0 1 0 1.5h-1a.75.75 0 0 1-.75-.75m4.75-.75a.75.75 0 0 0 0 1.5h1a.75.75 0 0 0 0-1.5zM10.75 16a.75.75 0 0 1 .75-.75h1a.75.75 0 0 1 0 1.5h-1a.75.75 0 0 1-.75-.75m4.75-.75a.75.75 0 0 0 0 1.5h1a.75.75 0 0 0 0-1.5zM6.75 16a.75.75 0 0 1 .75-.75h1a.75.75 0 0 1 0 1.5h-1a.75.75 0 0 1-.75-.75"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                          <div
+                            aria-live="polite"
+                            aria-relevant="additions removals"
+                            class="navds-form-field__error"
+                            id="datepicker-input-error-r1g"
+                          />
+                        </div>
+                        <div
+                          aria-hidden="true"
+                          class="navds-popover navds-date__popover navds-popover--hidden"
+                          data-index="0"
+                          data-placement="bottom-start"
+                          id="r1f"
+                          role="dialog"
+                          style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 0px);"
+                        >
+                          <div
+                            class="rdp navds-date"
+                          >
+                            <div
+                              class="rdp-months"
+                            >
+                              <div
+                                class="rdp-month rdp-caption_start rdp-caption_end"
+                              >
+                                <div
+                                  class="navds-date__caption"
+                                >
+                                  <span
+                                    aria-atomic="true"
+                                    aria-live="polite"
+                                    class="navds-sr-only"
+                                    id="react-day-picker-1"
+                                  >
+                                    januar 2024
+                                  </span>
+                                  <button
+                                    class="navds-date__caption-button navds-button navds-button--tertiary navds-button--medium navds-button--icon-only navds-button--disabled"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    <span
+                                      class="navds-button__icon"
+                                    >
+                                      <svg
+                                        aria-labelledby="title-r1j"
+                                        fill="none"
+                                        focusable="false"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 24 24"
+                                        width="1em"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <title
+                                          id="title-r1j"
+                                        >
+                                          Gå til forrige måned
+                                        </title>
+                                        <path
+                                          d="M4.47 11.47a.75.75 0 0 0 0 1.06l4.5 4.5a.75.75 0 0 0 1.06-1.06l-3.22-3.22H19a.75.75 0 0 0 0-1.5H6.81l3.22-3.22a.75.75 0 1 0-1.06-1.06z"
+                                          fill="currentColor"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </button>
+                                  <div
+                                    class="navds-date__caption"
+                                  >
+                                    <div
+                                      class="navds-date__caption__month navds-form-field navds-form-field--medium"
+                                    >
+                                      <label
+                                        class="navds-form-field__label navds-sr-only navds-label"
+                                        for="select-r1k"
+                                      >
+                                        Måned
+                                      </label>
+                                      <div
+                                        class="navds-select__container"
+                                      >
+                                        <select
+                                          class="navds-select__input navds-body-short navds-body-short--medium"
+                                          id="select-r1k"
+                                        >
+                                          <option
+                                            value="0"
+                                          >
+                                            januar
+                                          </option>
+                                          <option
+                                            value="1"
+                                          >
+                                            februar
+                                          </option>
+                                          <option
+                                            value="2"
+                                          >
+                                            mars
+                                          </option>
+                                          <option
+                                            value="3"
+                                          >
+                                            april
+                                          </option>
+                                          <option
+                                            value="4"
+                                          >
+                                            mai
+                                          </option>
+                                          <option
+                                            value="5"
+                                          >
+                                            juni
+                                          </option>
+                                          <option
+                                            value="6"
+                                          >
+                                            juli
+                                          </option>
+                                          <option
+                                            value="7"
+                                          >
+                                            august
+                                          </option>
+                                          <option
+                                            value="8"
+                                          >
+                                            september
+                                          </option>
+                                          <option
+                                            value="9"
+                                          >
+                                            oktober
+                                          </option>
+                                          <option
+                                            value="10"
+                                          >
+                                            november
+                                          </option>
+                                          <option
+                                            value="11"
+                                          >
+                                            desember
+                                          </option>
+                                        </select>
+                                        <svg
+                                          aria-hidden="true"
+                                          class="navds-select__chevron"
+                                          fill="none"
+                                          focusable="false"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 24 24"
+                                          width="1em"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            clip-rule="evenodd"
+                                            d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
+                                            fill="currentColor"
+                                            fill-rule="evenodd"
+                                          />
+                                        </svg>
+                                      </div>
+                                      <div
+                                        aria-live="polite"
+                                        aria-relevant="additions removals"
+                                        class="navds-form-field__error"
+                                        id="select-error-r1k"
+                                      />
+                                    </div>
+                                    <div
+                                      class="navds-date__caption__year navds-form-field navds-form-field--medium"
+                                    >
+                                      <label
+                                        class="navds-form-field__label navds-sr-only navds-label"
+                                        for="select-r1m"
+                                      >
+                                        År
+                                      </label>
+                                      <div
+                                        class="navds-select__container"
+                                      >
+                                        <select
+                                          class="navds-select__input navds-body-short navds-body-short--medium"
+                                          id="select-r1m"
+                                        >
+                                          <option
+                                            value="2044"
+                                          >
+                                            2044
+                                          </option>
+                                          <option
+                                            value="2043"
+                                          >
+                                            2043
+                                          </option>
+                                          <option
+                                            value="2042"
+                                          >
+                                            2042
+                                          </option>
+                                          <option
+                                            value="2041"
+                                          >
+                                            2041
+                                          </option>
+                                          <option
+                                            value="2040"
+                                          >
+                                            2040
+                                          </option>
+                                          <option
+                                            value="2039"
+                                          >
+                                            2039
+                                          </option>
+                                          <option
+                                            value="2038"
+                                          >
+                                            2038
+                                          </option>
+                                          <option
+                                            value="2037"
+                                          >
+                                            2037
+                                          </option>
+                                          <option
+                                            value="2036"
+                                          >
+                                            2036
+                                          </option>
+                                          <option
+                                            value="2035"
+                                          >
+                                            2035
+                                          </option>
+                                          <option
+                                            value="2034"
+                                          >
+                                            2034
+                                          </option>
+                                          <option
+                                            value="2033"
+                                          >
+                                            2033
+                                          </option>
+                                          <option
+                                            value="2032"
+                                          >
+                                            2032
+                                          </option>
+                                          <option
+                                            value="2031"
+                                          >
+                                            2031
+                                          </option>
+                                          <option
+                                            value="2030"
+                                          >
+                                            2030
+                                          </option>
+                                          <option
+                                            value="2029"
+                                          >
+                                            2029
+                                          </option>
+                                          <option
+                                            value="2028"
+                                          >
+                                            2028
+                                          </option>
+                                          <option
+                                            value="2027"
+                                          >
+                                            2027
+                                          </option>
+                                          <option
+                                            value="2026"
+                                          >
+                                            2026
+                                          </option>
+                                          <option
+                                            value="2025"
+                                          >
+                                            2025
+                                          </option>
+                                          <option
+                                            value="2024"
+                                          >
+                                            2024
+                                          </option>
+                                        </select>
+                                        <svg
+                                          aria-hidden="true"
+                                          class="navds-select__chevron"
+                                          fill="none"
+                                          focusable="false"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 24 24"
+                                          width="1em"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            clip-rule="evenodd"
+                                            d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
+                                            fill="currentColor"
+                                            fill-rule="evenodd"
+                                          />
+                                        </svg>
+                                      </div>
+                                      <div
+                                        aria-live="polite"
+                                        aria-relevant="additions removals"
+                                        class="navds-form-field__error"
+                                        id="select-error-r1m"
+                                      />
+                                    </div>
+                                  </div>
+                                  <button
+                                    class="navds-date__caption-button navds-button navds-button--tertiary navds-button--medium navds-button--icon-only"
+                                    type="button"
+                                  >
+                                    <span
+                                      class="navds-button__icon"
+                                    >
+                                      <svg
+                                        aria-labelledby="title-r1o"
+                                        fill="none"
+                                        focusable="false"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 24 24"
+                                        width="1em"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <title
+                                          id="title-r1o"
+                                        >
+                                          Gå til neste måned
+                                        </title>
+                                        <path
+                                          d="M14.087 6.874a.752.752 0 0 0-.117 1.156l3.22 3.22H5a.75.75 0 0 0 0 1.5h12.19l-3.22 3.22a.75.75 0 0 0 1.06 1.06l4.5-4.5a.75.75 0 0 0 0-1.06l-4.5-4.5a.75.75 0 0 0-.943-.096"
+                                          fill="currentColor"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </button>
+                                </div>
+                                <table
+                                  aria-labelledby="react-day-picker-1"
+                                  class="rdp-table"
+                                  role="grid"
+                                >
+                                  <thead
+                                    aria-hidden="true"
+                                    class="rdp-head"
+                                  >
+                                    <tr
+                                      class="rdp-head_row"
+                                    >
+                                      <th
+                                        aria-label="mandag"
+                                        class="rdp-head_cell"
+                                        scope="col"
+                                      >
+                                        ma
+                                      </th>
+                                      <th
+                                        aria-label="tirsdag"
+                                        class="rdp-head_cell"
+                                        scope="col"
+                                      >
+                                        ti
+                                      </th>
+                                      <th
+                                        aria-label="onsdag"
+                                        class="rdp-head_cell"
+                                        scope="col"
+                                      >
+                                        on
+                                      </th>
+                                      <th
+                                        aria-label="torsdag"
+                                        class="rdp-head_cell"
+                                        scope="col"
+                                      >
+                                        to
+                                      </th>
+                                      <th
+                                        aria-label="fredag"
+                                        class="rdp-head_cell"
+                                        scope="col"
+                                      >
+                                        fr
+                                      </th>
+                                      <th
+                                        aria-label="lørdag"
+                                        class="rdp-head_cell"
+                                        scope="col"
+                                      >
+                                        lø
+                                      </th>
+                                      <th
+                                        aria-label="søndag"
+                                        class="rdp-head_cell"
+                                        scope="col"
+                                      >
+                                        sø
+                                      </th>
+                                    </tr>
+                                  </thead>
+                                  <tbody
+                                    class="rdp-tbody"
+                                  >
+                                    <tr
+                                      class="rdp-row"
+                                    >
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="mandag 1"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day rdp-day_today"
+                                          name="day"
+                                          tabindex="0"
+                                          type="button"
+                                        >
+                                          1
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="tirsdag 2"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          2
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="onsdag 3"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          3
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="torsdag 4"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          4
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="fredag 5"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          5
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="lørdag 6"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          6
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="søndag 7"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          7
+                                        </button>
+                                      </td>
+                                    </tr>
+                                    <tr
+                                      class="rdp-row"
+                                    >
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="mandag 8"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          8
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="tirsdag 9"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          9
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="onsdag 10"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          10
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="torsdag 11"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          11
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="fredag 12"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          12
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="lørdag 13"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          13
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="søndag 14"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          14
+                                        </button>
+                                      </td>
+                                    </tr>
+                                    <tr
+                                      class="rdp-row"
+                                    >
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="mandag 15"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          15
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="tirsdag 16"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          16
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="onsdag 17"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          17
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="torsdag 18"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          18
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="fredag 19"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          19
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="lørdag 20"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          20
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="søndag 21"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          21
+                                        </button>
+                                      </td>
+                                    </tr>
+                                    <tr
+                                      class="rdp-row"
+                                    >
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="mandag 22"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          22
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="tirsdag 23"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          23
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="onsdag 24"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          24
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="torsdag 25"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          25
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="fredag 26"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          26
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="lørdag 27"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          27
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="søndag 28"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          28
+                                        </button>
+                                      </td>
+                                    </tr>
+                                    <tr
+                                      class="rdp-row"
+                                    >
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="mandag 29"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          29
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="tirsdag 30"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          30
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-label="onsdag 31"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          31
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-hidden="true"
+                                          aria-label="torsdag 1"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          1
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-hidden="true"
+                                          aria-label="fredag 2"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          2
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-hidden="true"
+                                          aria-label="lørdag 3"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          3
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-hidden="true"
+                                          aria-label="søndag 4"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          4
+                                        </button>
+                                      </td>
+                                    </tr>
+                                    <tr
+                                      class="rdp-row"
+                                    >
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-hidden="true"
+                                          aria-label="mandag 5"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          5
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-hidden="true"
+                                          aria-label="tirsdag 6"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          6
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-hidden="true"
+                                          aria-label="onsdag 7"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          7
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-hidden="true"
+                                          aria-label="torsdag 8"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          8
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-hidden="true"
+                                          aria-label="fredag 9"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          9
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-hidden="true"
+                                          aria-label="lørdag 10"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          10
+                                        </button>
+                                      </td>
+                                      <td
+                                        class="rdp-cell"
+                                      >
+                                        <button
+                                          aria-hidden="true"
+                                          aria-label="søndag 11"
+                                          aria-pressed="false"
+                                          class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
+                                          name="day"
+                                          tabindex="-1"
+                                          type="button"
+                                        >
+                                          11
+                                        </button>
+                                      </td>
+                                    </tr>
+                                  </tbody>
+                                </table>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </section>
+                  </div>
+                </div>
+              </div>
+            </fieldset>
+            <fieldset
+              class="sc-blHHSb hqrzOP"
+            >
+              <div
+                id="arbeidsforhold[0].forventerEndretArbeidssituasjon.svar"
+              >
+                <fieldset
+                  class="navds-radio-group navds-radio-group--medium navds-fieldset navds-fieldset--medium"
+                >
+                  <legend
+                    class="navds-fieldset__legend navds-label"
+                  >
+                    merOmSituasjonenDin.arbeidsforhold.forventerEndretArbeidssituasjon.svar
+                  </legend>
+                  <div
+                    class="navds-radio-buttons"
+                  >
+                    <div
+                      class="radioBorder navds-radio navds-radio--medium"
+                    >
+                      <input
+                        aria-labelledby="r1t"
+                        class="navds-radio__input"
+                        id="radio-r1s"
+                        name="arbeidsforhold[0].forventerEndretArbeidssituasjon.svar"
+                        type="radio"
+                        value="radiobuttons.ja"
+                      />
+                      <label
+                        class="navds-radio__label"
+                        for="radio-r1s"
+                      >
+                        <span
+                          class="navds-radio__content"
+                        >
+                          <span
+                            aria-hidden="true"
+                            class="navds-body-short navds-body-short--medium"
+                            id="r1t"
+                          >
+                            radiobuttons.ja
+                          </span>
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      class="radioBorder navds-radio navds-radio--medium"
+                    >
+                      <input
+                        aria-labelledby="r20"
+                        class="navds-radio__input"
+                        id="radio-r1v"
+                        name="arbeidsforhold[0].forventerEndretArbeidssituasjon.svar"
+                        type="radio"
+                        value="radiobuttons.nei"
+                      />
+                      <label
+                        class="navds-radio__label"
+                        for="radio-r1v"
+                      >
+                        <span
+                          class="navds-radio__content"
+                        >
+                          <span
+                            aria-hidden="true"
+                            class="navds-body-short navds-body-short--medium"
+                            id="r20"
+                          >
+                            radiobuttons.nei
+                          </span>
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                  <div
+                    aria-live="polite"
+                    aria-relevant="additions removals"
+                    class="navds-fieldset__error"
+                    id="fieldset-error-r1r"
+                  />
+                </fieldset>
+              </div>
+              <div
+                style="display: none;"
+              >
+                <div
+                  class="sc-cHqXqK jvHoMc"
+                >
+                  <div
+                    class="width-50"
+                  >
+                    <div
+                      class="navds-form-field navds-form-field--medium"
+                    >
+                      <label
+                        class="navds-form-field__label navds-label"
+                        for="arbeidsforhold[0].forventerEndretArbeidssituasjon.beskrivelse"
+                      >
+                        merOmSituasjonenDin.arbeidsforhold.forventerEndretArbeidssituasjon.beskrivelse
+                      </label>
+                      <div
+                        class="navds-form-field__description navds-body-short navds-body-short--medium"
+                        id="textarea-description-r22"
+                      >
+                        felles.ikkeSensitiveOpplysninger
+                      </div>
+                      <textarea
+                        aria-describedby="textarea-description-r22 r23"
+                        class="navds-textarea__input navds-body-short navds-body-short--medium"
+                        id="arbeidsforhold[0].forventerEndretArbeidssituasjon.beskrivelse"
+                        rows="3"
+                        style="--__ac-textarea-height: -4px; overflow: hidden;"
+                      />
+                      <textarea
+                        aria-hidden="true"
+                        class="navds-textarea__input navds-body-short navds-body-short--medium"
+                        readonly=""
+                        style="visibility: hidden; position: absolute; overflow: hidden; height: 0px; top: 0px; left: 0px; transform: translateZ(0);"
+                        tabindex="-1"
+                      />
+                      <span
+                        class="navds-sr-only"
+                        id="r23"
+                      >
+                        Tekstområde med plass til 200 tegn.
+                      </span>
+                      <p
+                        class="navds-textarea__counter navds-body-short navds-body-short--medium"
+                      >
+                        200 counterLeft
+                      </p>
                       <div
                         aria-live="polite"
                         aria-relevant="additions removals"
                         class="navds-form-field__error"
-                        id="datepicker-input-error-r1g"
+                        id="textarea-error-r22"
                       />
                     </div>
-                    <div
-                      aria-hidden="true"
-                      class="navds-popover navds-date__popover navds-popover--hidden"
-                      data-index="0"
-                      data-placement="bottom-start"
-                      id="r1f"
-                      role="dialog"
-                      style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 0px);"
-                    >
-                      <div
-                        class="rdp navds-date"
-                      >
-                        <div
-                          class="rdp-months"
-                        >
-                          <div
-                            class="rdp-month rdp-caption_start rdp-caption_end"
-                          >
-                            <div
-                              class="navds-date__caption"
-                            >
-                              <span
-                                aria-atomic="true"
-                                aria-live="polite"
-                                class="navds-sr-only"
-                                id="react-day-picker-1"
-                              >
-                                januar 2024
-                              </span>
-                              <button
-                                class="navds-date__caption-button navds-button navds-button--tertiary navds-button--medium navds-button--icon-only navds-button--disabled"
-                                disabled=""
-                                type="button"
-                              >
-                                <span
-                                  class="navds-button__icon"
-                                >
-                                  <svg
-                                    aria-labelledby="title-r1j"
-                                    fill="none"
-                                    focusable="false"
-                                    height="1em"
-                                    role="img"
-                                    viewBox="0 0 24 24"
-                                    width="1em"
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <title
-                                      id="title-r1j"
-                                    >
-                                      Gå til forrige måned
-                                    </title>
-                                    <path
-                                      d="M4.47 11.47a.75.75 0 0 0 0 1.06l4.5 4.5a.75.75 0 0 0 1.06-1.06l-3.22-3.22H19a.75.75 0 0 0 0-1.5H6.81l3.22-3.22a.75.75 0 1 0-1.06-1.06z"
-                                      fill="currentColor"
-                                    />
-                                  </svg>
-                                </span>
-                              </button>
-                              <div
-                                class="navds-date__caption"
-                              >
-                                <div
-                                  class="navds-date__caption__month navds-form-field navds-form-field--medium"
-                                >
-                                  <label
-                                    class="navds-form-field__label navds-sr-only navds-label"
-                                    for="select-r1k"
-                                  >
-                                    Måned
-                                  </label>
-                                  <div
-                                    class="navds-select__container"
-                                  >
-                                    <select
-                                      class="navds-select__input navds-body-short navds-body-short--medium"
-                                      id="select-r1k"
-                                    >
-                                      <option
-                                        value="0"
-                                      >
-                                        januar
-                                      </option>
-                                      <option
-                                        value="1"
-                                      >
-                                        februar
-                                      </option>
-                                      <option
-                                        value="2"
-                                      >
-                                        mars
-                                      </option>
-                                      <option
-                                        value="3"
-                                      >
-                                        april
-                                      </option>
-                                      <option
-                                        value="4"
-                                      >
-                                        mai
-                                      </option>
-                                      <option
-                                        value="5"
-                                      >
-                                        juni
-                                      </option>
-                                      <option
-                                        value="6"
-                                      >
-                                        juli
-                                      </option>
-                                      <option
-                                        value="7"
-                                      >
-                                        august
-                                      </option>
-                                      <option
-                                        value="8"
-                                      >
-                                        september
-                                      </option>
-                                      <option
-                                        value="9"
-                                      >
-                                        oktober
-                                      </option>
-                                      <option
-                                        value="10"
-                                      >
-                                        november
-                                      </option>
-                                      <option
-                                        value="11"
-                                      >
-                                        desember
-                                      </option>
-                                    </select>
-                                    <svg
-                                      aria-hidden="true"
-                                      class="navds-select__chevron"
-                                      fill="none"
-                                      focusable="false"
-                                      height="1em"
-                                      role="img"
-                                      viewBox="0 0 24 24"
-                                      width="1em"
-                                      xmlns="http://www.w3.org/2000/svg"
-                                    >
-                                      <path
-                                        clip-rule="evenodd"
-                                        d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
-                                        fill="currentColor"
-                                        fill-rule="evenodd"
-                                      />
-                                    </svg>
-                                  </div>
-                                  <div
-                                    aria-live="polite"
-                                    aria-relevant="additions removals"
-                                    class="navds-form-field__error"
-                                    id="select-error-r1k"
-                                  />
-                                </div>
-                                <div
-                                  class="navds-date__caption__year navds-form-field navds-form-field--medium"
-                                >
-                                  <label
-                                    class="navds-form-field__label navds-sr-only navds-label"
-                                    for="select-r1m"
-                                  >
-                                    År
-                                  </label>
-                                  <div
-                                    class="navds-select__container"
-                                  >
-                                    <select
-                                      class="navds-select__input navds-body-short navds-body-short--medium"
-                                      id="select-r1m"
-                                    >
-                                      <option
-                                        value="2044"
-                                      >
-                                        2044
-                                      </option>
-                                      <option
-                                        value="2043"
-                                      >
-                                        2043
-                                      </option>
-                                      <option
-                                        value="2042"
-                                      >
-                                        2042
-                                      </option>
-                                      <option
-                                        value="2041"
-                                      >
-                                        2041
-                                      </option>
-                                      <option
-                                        value="2040"
-                                      >
-                                        2040
-                                      </option>
-                                      <option
-                                        value="2039"
-                                      >
-                                        2039
-                                      </option>
-                                      <option
-                                        value="2038"
-                                      >
-                                        2038
-                                      </option>
-                                      <option
-                                        value="2037"
-                                      >
-                                        2037
-                                      </option>
-                                      <option
-                                        value="2036"
-                                      >
-                                        2036
-                                      </option>
-                                      <option
-                                        value="2035"
-                                      >
-                                        2035
-                                      </option>
-                                      <option
-                                        value="2034"
-                                      >
-                                        2034
-                                      </option>
-                                      <option
-                                        value="2033"
-                                      >
-                                        2033
-                                      </option>
-                                      <option
-                                        value="2032"
-                                      >
-                                        2032
-                                      </option>
-                                      <option
-                                        value="2031"
-                                      >
-                                        2031
-                                      </option>
-                                      <option
-                                        value="2030"
-                                      >
-                                        2030
-                                      </option>
-                                      <option
-                                        value="2029"
-                                      >
-                                        2029
-                                      </option>
-                                      <option
-                                        value="2028"
-                                      >
-                                        2028
-                                      </option>
-                                      <option
-                                        value="2027"
-                                      >
-                                        2027
-                                      </option>
-                                      <option
-                                        value="2026"
-                                      >
-                                        2026
-                                      </option>
-                                      <option
-                                        value="2025"
-                                      >
-                                        2025
-                                      </option>
-                                      <option
-                                        value="2024"
-                                      >
-                                        2024
-                                      </option>
-                                    </select>
-                                    <svg
-                                      aria-hidden="true"
-                                      class="navds-select__chevron"
-                                      fill="none"
-                                      focusable="false"
-                                      height="1em"
-                                      role="img"
-                                      viewBox="0 0 24 24"
-                                      width="1em"
-                                      xmlns="http://www.w3.org/2000/svg"
-                                    >
-                                      <path
-                                        clip-rule="evenodd"
-                                        d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
-                                        fill="currentColor"
-                                        fill-rule="evenodd"
-                                      />
-                                    </svg>
-                                  </div>
-                                  <div
-                                    aria-live="polite"
-                                    aria-relevant="additions removals"
-                                    class="navds-form-field__error"
-                                    id="select-error-r1m"
-                                  />
-                                </div>
-                              </div>
-                              <button
-                                class="navds-date__caption-button navds-button navds-button--tertiary navds-button--medium navds-button--icon-only"
-                                type="button"
-                              >
-                                <span
-                                  class="navds-button__icon"
-                                >
-                                  <svg
-                                    aria-labelledby="title-r1o"
-                                    fill="none"
-                                    focusable="false"
-                                    height="1em"
-                                    role="img"
-                                    viewBox="0 0 24 24"
-                                    width="1em"
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <title
-                                      id="title-r1o"
-                                    >
-                                      Gå til neste måned
-                                    </title>
-                                    <path
-                                      d="M14.087 6.874a.752.752 0 0 0-.117 1.156l3.22 3.22H5a.75.75 0 0 0 0 1.5h12.19l-3.22 3.22a.75.75 0 0 0 1.06 1.06l4.5-4.5a.75.75 0 0 0 0-1.06l-4.5-4.5a.75.75 0 0 0-.943-.096"
-                                      fill="currentColor"
-                                    />
-                                  </svg>
-                                </span>
-                              </button>
-                            </div>
-                            <table
-                              aria-labelledby="react-day-picker-1"
-                              class="rdp-table"
-                              role="grid"
-                            >
-                              <thead
-                                aria-hidden="true"
-                                class="rdp-head"
-                              >
-                                <tr
-                                  class="rdp-head_row"
-                                >
-                                  <th
-                                    aria-label="mandag"
-                                    class="rdp-head_cell"
-                                    scope="col"
-                                  >
-                                    ma
-                                  </th>
-                                  <th
-                                    aria-label="tirsdag"
-                                    class="rdp-head_cell"
-                                    scope="col"
-                                  >
-                                    ti
-                                  </th>
-                                  <th
-                                    aria-label="onsdag"
-                                    class="rdp-head_cell"
-                                    scope="col"
-                                  >
-                                    on
-                                  </th>
-                                  <th
-                                    aria-label="torsdag"
-                                    class="rdp-head_cell"
-                                    scope="col"
-                                  >
-                                    to
-                                  </th>
-                                  <th
-                                    aria-label="fredag"
-                                    class="rdp-head_cell"
-                                    scope="col"
-                                  >
-                                    fr
-                                  </th>
-                                  <th
-                                    aria-label="lørdag"
-                                    class="rdp-head_cell"
-                                    scope="col"
-                                  >
-                                    lø
-                                  </th>
-                                  <th
-                                    aria-label="søndag"
-                                    class="rdp-head_cell"
-                                    scope="col"
-                                  >
-                                    sø
-                                  </th>
-                                </tr>
-                              </thead>
-                              <tbody
-                                class="rdp-tbody"
-                              >
-                                <tr
-                                  class="rdp-row"
-                                >
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="mandag 1"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day rdp-day_today"
-                                      name="day"
-                                      tabindex="0"
-                                      type="button"
-                                    >
-                                      1
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="tirsdag 2"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      2
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="onsdag 3"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      3
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="torsdag 4"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      4
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="fredag 5"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      5
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="lørdag 6"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      6
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="søndag 7"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      7
-                                    </button>
-                                  </td>
-                                </tr>
-                                <tr
-                                  class="rdp-row"
-                                >
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="mandag 8"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      8
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="tirsdag 9"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      9
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="onsdag 10"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      10
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="torsdag 11"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      11
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="fredag 12"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      12
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="lørdag 13"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      13
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="søndag 14"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      14
-                                    </button>
-                                  </td>
-                                </tr>
-                                <tr
-                                  class="rdp-row"
-                                >
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="mandag 15"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      15
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="tirsdag 16"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      16
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="onsdag 17"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      17
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="torsdag 18"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      18
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="fredag 19"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      19
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="lørdag 20"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      20
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="søndag 21"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      21
-                                    </button>
-                                  </td>
-                                </tr>
-                                <tr
-                                  class="rdp-row"
-                                >
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="mandag 22"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      22
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="tirsdag 23"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      23
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="onsdag 24"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      24
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="torsdag 25"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      25
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="fredag 26"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      26
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="lørdag 27"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      27
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="søndag 28"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      28
-                                    </button>
-                                  </td>
-                                </tr>
-                                <tr
-                                  class="rdp-row"
-                                >
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="mandag 29"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      29
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="tirsdag 30"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      30
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-label="onsdag 31"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      31
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-hidden="true"
-                                      aria-label="torsdag 1"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      1
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-hidden="true"
-                                      aria-label="fredag 2"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      2
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-hidden="true"
-                                      aria-label="lørdag 3"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      3
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-hidden="true"
-                                      aria-label="søndag 4"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      4
-                                    </button>
-                                  </td>
-                                </tr>
-                                <tr
-                                  class="rdp-row"
-                                >
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-hidden="true"
-                                      aria-label="mandag 5"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      5
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-hidden="true"
-                                      aria-label="tirsdag 6"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      6
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-hidden="true"
-                                      aria-label="onsdag 7"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      7
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-hidden="true"
-                                      aria-label="torsdag 8"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      8
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-hidden="true"
-                                      aria-label="fredag 9"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      9
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-hidden="true"
-                                      aria-label="lørdag 10"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      10
-                                    </button>
-                                  </td>
-                                  <td
-                                    class="rdp-cell"
-                                  >
-                                    <button
-                                      aria-hidden="true"
-                                      aria-label="søndag 11"
-                                      aria-pressed="false"
-                                      class="rdp-button_reset rdp-button rdp-day rdp-day_outside"
-                                      name="day"
-                                      tabindex="-1"
-                                      type="button"
-                                    >
-                                      11
-                                    </button>
-                                  </td>
-                                </tr>
-                              </tbody>
-                            </table>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
                   </div>
-                </section>
-              </div>
-            </div>
-          </div>
-        </fieldset>
-        <fieldset
-          class="sc-blHHSb hqrzOP"
-        >
-          <div
-            id="arbeidsforhold[0].forventerEndretArbeidssituasjon.svar"
-          >
-            <fieldset
-              class="navds-radio-group navds-radio-group--medium navds-fieldset navds-fieldset--medium"
-            >
-              <legend
-                class="navds-fieldset__legend navds-label"
-              >
-                merOmSituasjonenDin.arbeidsforhold.forventerEndretArbeidssituasjon.svar
-              </legend>
-              <div
-                class="navds-radio-buttons"
-              >
-                <div
-                  class="radioBorder navds-radio navds-radio--medium"
-                >
-                  <input
-                    aria-labelledby="r1t"
-                    class="navds-radio__input"
-                    id="radio-r1s"
-                    name="arbeidsforhold[0].forventerEndretArbeidssituasjon.svar"
-                    type="radio"
-                    value="radiobuttons.ja"
-                  />
-                  <label
-                    class="navds-radio__label"
-                    for="radio-r1s"
-                  >
-                    <span
-                      class="navds-radio__content"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="navds-body-short navds-body-short--medium"
-                        id="r1t"
-                      >
-                        radiobuttons.ja
-                      </span>
-                    </span>
-                  </label>
-                </div>
-                <div
-                  class="radioBorder navds-radio navds-radio--medium"
-                >
-                  <input
-                    aria-labelledby="r20"
-                    class="navds-radio__input"
-                    id="radio-r1v"
-                    name="arbeidsforhold[0].forventerEndretArbeidssituasjon.svar"
-                    type="radio"
-                    value="radiobuttons.nei"
-                  />
-                  <label
-                    class="navds-radio__label"
-                    for="radio-r1v"
-                  >
-                    <span
-                      class="navds-radio__content"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="navds-body-short navds-body-short--medium"
-                        id="r20"
-                      >
-                        radiobuttons.nei
-                      </span>
-                    </span>
-                  </label>
                 </div>
               </div>
               <div
-                aria-live="polite"
-                aria-relevant="additions removals"
-                class="navds-fieldset__error"
-                id="fieldset-error-r1r"
-              />
+                class="navds-read-more navds-read-more--medium"
+              >
+                <button
+                  aria-expanded="false"
+                  class="navds-read-more__button navds-body-short"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="navds-read-more__expand-icon"
+                    fill="none"
+                    focusable="false"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 24 24"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                  <span>
+                    hvorforSpoerVi
+                  </span>
+                </button>
+                <div
+                  aria-hidden="true"
+                  class="navds-read-more__content navds-read-more__content--closed navds-body-long navds-body-long--medium"
+                >
+                  merOmSituasjonenDin.arbeidsforhold.sagtOppEllerRedusert.hvorfor
+                </div>
+              </div>
             </fieldset>
           </div>
-          <div
-            style="display: none;"
-          >
-            <div
-              class="sc-cHqXqK jvHoMc"
-            >
-              <div
-                class="width-50"
-              >
-                <div
-                  class="navds-form-field navds-form-field--medium"
-                >
-                  <label
-                    class="navds-form-field__label navds-label"
-                    for="arbeidsforhold[0].forventerEndretArbeidssituasjon.beskrivelse"
-                  >
-                    merOmSituasjonenDin.arbeidsforhold.forventerEndretArbeidssituasjon.beskrivelse
-                  </label>
-                  <div
-                    class="navds-form-field__description navds-body-short navds-body-short--medium"
-                    id="textarea-description-r22"
-                  >
-                    felles.ikkeSensitiveOpplysninger
-                  </div>
-                  <textarea
-                    aria-describedby="textarea-description-r22 r23"
-                    class="navds-textarea__input navds-body-short navds-body-short--medium"
-                    id="arbeidsforhold[0].forventerEndretArbeidssituasjon.beskrivelse"
-                    rows="3"
-                    style="--__ac-textarea-height: -4px; overflow: hidden;"
-                  />
-                  <textarea
-                    aria-hidden="true"
-                    class="navds-textarea__input navds-body-short navds-body-short--medium"
-                    readonly=""
-                    style="visibility: hidden; position: absolute; overflow: hidden; height: 0px; top: 0px; left: 0px; transform: translateZ(0);"
-                    tabindex="-1"
-                  />
-                  <span
-                    class="navds-sr-only"
-                    id="r23"
-                  >
-                    Tekstområde med plass til 200 tegn.
-                  </span>
-                  <p
-                    class="navds-textarea__counter navds-body-short navds-body-short--medium"
-                  >
-                    200 counterLeft
-                  </p>
-                  <div
-                    aria-live="polite"
-                    aria-relevant="additions removals"
-                    class="navds-form-field__error"
-                    id="textarea-error-r22"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="navds-read-more navds-read-more--medium"
-          >
+          <div>
             <button
-              aria-expanded="false"
-              class="navds-read-more__button navds-body-short"
+              class="navds-button navds-button--secondary navds-button--medium"
+              data-testid="legg-til-arbeidsforhold-knapp"
               type="button"
             >
-              <svg
-                aria-hidden="true"
-                class="navds-read-more__expand-icon"
-                fill="none"
-                focusable="false"
-                height="1em"
-                role="img"
-                viewBox="0 0 24 24"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
+              <span
+                class="navds-label"
               >
-                <path
-                  clip-rule="evenodd"
-                  d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
-                  fill="currentColor"
-                  fill-rule="evenodd"
-                />
-              </svg>
-              <span>
-                hvorforSpoerVi
+                + 
+                knapp.leggTilArbeidsforhold
               </span>
             </button>
-            <div
-              aria-hidden="true"
-              class="navds-read-more__content navds-read-more__content--closed navds-body-long navds-body-long--medium"
-            >
-              merOmSituasjonenDin.arbeidsforhold.sagtOppEllerRedusert.hvorfor
-            </div>
           </div>
-        </fieldset>
-        <button
-          class="navds-button navds-button--secondary navds-button--medium"
-          data-testid="legg-til-arbeidsforhold-knapp"
-          type="button"
-        >
-          <span
-            class="navds-label"
-          >
-            + 
-            knapp.leggTilArbeidsforhold
-          </span>
-        </button>
+        </div>
       </fieldset>
     </div>
     <fieldset

--- a/apps/omstillingsstoenad-ui/src/components/soknad/5-mer-om-situasjonen-din/fragmenter/Arbeidstaker.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/soknad/5-mer-om-situasjonen-din/fragmenter/Arbeidstaker.tsx
@@ -1,6 +1,6 @@
 import { FieldArrayWithId, useFieldArray, useFormContext } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
-import { Button, Heading } from '@navikt/ds-react'
+import { Button, Heading, VStack } from '@navikt/ds-react'
 import ArbeidstakerInfokort from './ArbeidstakerInfokort'
 import { useEffect } from 'react'
 import { SkjemaElement } from '../../../felles/SkjemaElement'
@@ -40,19 +40,23 @@ const Arbeidstaker = () => {
                 <Heading size={'small'}>{t('merOmSituasjonenDin.arbeidsforhold.tittel')}</Heading>
             </SkjemaElement>
 
-            {fields.map((field: FieldArrayWithId, index: number) => (
-                <ArbeidstakerInfokort key={field.id} lengde={fields.length} index={index} fjern={fjern} />
-            ))}
+            <VStack gap="4">
+                {fields.map((field: FieldArrayWithId, index: number) => (
+                    <ArbeidstakerInfokort key={field.id} lengde={fields.length} index={index} fjern={fjern} />
+                ))}
 
-            <Button
-                variant={'secondary'}
-                type={'button'}
-                onClick={nyttArbeidsforhold}
-                disabled={fields.length >= 10}
-                data-testid={'legg-til-arbeidsforhold-knapp'}
-            >
-                + {t('knapp.leggTilArbeidsforhold')}
-            </Button>
+                <div>
+                    <Button
+                        variant={'secondary'}
+                        type={'button'}
+                        onClick={nyttArbeidsforhold}
+                        disabled={fields.length >= 10}
+                        data-testid={'legg-til-arbeidsforhold-knapp'}
+                    >
+                        + {t('knapp.leggTilArbeidsforhold')}
+                    </Button>
+                </div>
+            </VStack>
         </SkjemaGruppe>
     )
 }

--- a/apps/omstillingsstoenad-ui/src/components/soknad/5-mer-om-situasjonen-din/fragmenter/ArbeidstakerInfokort.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/soknad/5-mer-om-situasjonen-din/fragmenter/ArbeidstakerInfokort.tsx
@@ -13,6 +13,7 @@ import Bredde from '../../../../typer/bredde'
 import { SkjemaGruppe } from '../../../felles/SkjemaGruppe'
 import { RHFSelect } from '../../../felles/rhf/RHFSelect'
 import { NumberSelectRad } from '../../../felles/StyledComponents'
+import { Panel } from '~components/felles/Panel'
 
 interface Props {
     lengde: number
@@ -72,7 +73,7 @@ const ArbeidstakerInfokort = memo(({ lengde, index, fjern }: Props) => {
     }, [ansettelsesforhold])
 
     return (
-        <>
+        <Panel borderColor={'border-info'} borderWidth={'0 0 0 4'} background={'surface-selected'}>
             {lengde > 1 && (
                 <Heading size={'small'}>{`${t('merOmSituasjonenDin.arbeidsforhold.arbeidssted')} ${
                     index + 1
@@ -205,14 +206,7 @@ const ArbeidstakerInfokort = memo(({ lengde, index, fjern }: Props) => {
             * */}
 
             {lengde > 1 && (
-                <div
-                    style={{
-                        textAlign: 'right',
-                        borderBottom: '1px solid grey',
-                        paddingBottom: '1rem',
-                        marginBottom: '1rem',
-                    }}
-                >
+                <div>
                     <Button
                         variant={'secondary'}
                         type={'button'}
@@ -224,7 +218,7 @@ const ArbeidstakerInfokort = memo(({ lengde, index, fjern }: Props) => {
                     </Button>
                 </div>
             )}
-        </>
+        </Panel>
     )
 })
 

--- a/apps/omstillingsstoenad-ui/src/components/soknad/5-mer-om-situasjonen-din/fragmenter/ArbeidstakerInfokort.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/soknad/5-mer-om-situasjonen-din/fragmenter/ArbeidstakerInfokort.tsx
@@ -1,7 +1,7 @@
 import { memo, useEffect, useState } from 'react'
 import { Arbeidsmengde, StillingType } from '../../../../typer/arbeidsforhold'
 import { useTranslation } from 'react-i18next'
-import { BodyShort, Button, Heading, RadioProps, ReadMore } from '@navikt/ds-react'
+import { BodyShort, Box, Button, Heading, RadioProps, ReadMore } from '@navikt/ds-react'
 import { RHFInput, RHFInputArea, RHFNumberInput, RHFProsentInput } from '../../../felles/rhf/RHFInput'
 import { RHFRadio, RHFSpoersmaalRadio } from '../../../felles/rhf/RHFRadio'
 import { IValg } from '../../../../typer/Spoersmaal'
@@ -13,7 +13,6 @@ import Bredde from '../../../../typer/bredde'
 import { SkjemaGruppe } from '../../../felles/SkjemaGruppe'
 import { RHFSelect } from '../../../felles/rhf/RHFSelect'
 import { NumberSelectRad } from '../../../felles/StyledComponents'
-import { Panel } from '~components/felles/Panel'
 
 interface Props {
     lengde: number
@@ -73,7 +72,7 @@ const ArbeidstakerInfokort = memo(({ lengde, index, fjern }: Props) => {
     }, [ansettelsesforhold])
 
     return (
-        <Panel borderColor={'border-info'} borderWidth={'0 0 0 4'} background={'surface-selected'}>
+        <Box padding="4" borderColor={'border-info'} borderWidth={'0 0 0 4'} background={'surface-selected'}>
             {lengde > 1 && (
                 <Heading size={'small'}>{`${t('merOmSituasjonenDin.arbeidsforhold.arbeidssted')} ${
                     index + 1
@@ -218,7 +217,7 @@ const ArbeidstakerInfokort = memo(({ lengde, index, fjern }: Props) => {
                     </Button>
                 </div>
             )}
-        </Panel>
+        </Box>
     )
 })
 

--- a/apps/omstillingsstoenad-ui/src/components/soknad/5-mer-om-situasjonen-din/fragmenter/Selvstendig.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/soknad/5-mer-om-situasjonen-din/fragmenter/Selvstendig.tsx
@@ -1,11 +1,10 @@
 import { useTranslation } from 'react-i18next'
-import { Button, Heading } from '@navikt/ds-react'
+import { Button, Heading, VStack } from '@navikt/ds-react'
 import { FieldArrayWithId, useFieldArray, useFormContext } from 'react-hook-form'
 import { useEffect } from 'react'
 import SelvstendigInfokort from './SelvstendigInfokort'
 import { SkjemaElement } from '../../../felles/SkjemaElement'
 import { SkjemaGruppe } from '../../../felles/SkjemaGruppe'
-
 
 const Selvstendig = () => {
     const { t } = useTranslation()
@@ -29,13 +28,17 @@ const Selvstendig = () => {
                 <Heading size={'small'}>{t('merOmSituasjonenDin.selvstendig.tittel')}</Heading>
             </SkjemaElement>
 
-            {fields.map((field: FieldArrayWithId, index: number) => (
-                <SelvstendigInfokort key={field.id} lengde={fields.length} index={index} fjern={remove} />
-            ))}
+            <VStack gap="4">
+                {fields.map((field: FieldArrayWithId, index: number) => (
+                    <SelvstendigInfokort key={field.id} lengde={fields.length} index={index} fjern={remove} />
+                ))}
 
-            <Button variant={'secondary'} type={'button'} onClick={() => append({}, { shouldFocus: true })}>
-                + {t('knapp.leggTilNaeringer')}
-            </Button>
+                <div>
+                    <Button variant={'secondary'} type={'button'} onClick={() => append({}, { shouldFocus: true })}>
+                        + {t('knapp.leggTilNaeringer')}
+                    </Button>
+                </div>
+            </VStack>
         </SkjemaGruppe>
     )
 }

--- a/apps/omstillingsstoenad-ui/src/components/soknad/5-mer-om-situasjonen-din/fragmenter/SelvstendigInfokort.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/soknad/5-mer-om-situasjonen-din/fragmenter/SelvstendigInfokort.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { BodyShort, Button, Label, ReadMore } from '@navikt/ds-react'
+import { BodyShort, Box, Button, Label, ReadMore } from '@navikt/ds-react'
 import { RHFInput, RHFInputArea, RHFNumberInput } from '../../../felles/rhf/RHFInput'
 import { RHFSpoersmaalRadio } from '../../../felles/rhf/RHFRadio'
 import { DeleteFilled } from '@navikt/ds-icons'
@@ -12,7 +12,6 @@ import { IValg } from '../../../../typer/Spoersmaal'
 import { RHFSelect } from '../../../felles/rhf/RHFSelect'
 import { NumberSelectRad } from '../../../felles/StyledComponents'
 import { SkjemaGruppe } from '../../../felles/SkjemaGruppe'
-import { Panel } from '~components/felles/Panel'
 
 interface Props {
     lengde: number
@@ -33,7 +32,7 @@ const SelvstendigInfokort = memo(({ lengde, index, fjern }: Props) => {
     })
 
     return (
-        <Panel borderColor={'border-info'} borderWidth={'0 0 0 4'} background={'surface-selected'}>
+        <Box padding="4" borderColor={'border-info'} borderWidth={'0 0 0 4'} background={'surface-selected'}>
             <SkjemaGruppe>
                 <RHFInput
                     name={`${selvstendigName}.beskrivelse` as const}
@@ -111,7 +110,7 @@ const SelvstendigInfokort = memo(({ lengde, index, fjern }: Props) => {
                     </Button>
                 </div>
             )}
-        </Panel>
+        </Box>
     )
 })
 

--- a/apps/omstillingsstoenad-ui/src/components/soknad/5-mer-om-situasjonen-din/fragmenter/SelvstendigInfokort.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/soknad/5-mer-om-situasjonen-din/fragmenter/SelvstendigInfokort.tsx
@@ -12,6 +12,7 @@ import { IValg } from '../../../../typer/Spoersmaal'
 import { RHFSelect } from '../../../felles/rhf/RHFSelect'
 import { NumberSelectRad } from '../../../felles/StyledComponents'
 import { SkjemaGruppe } from '../../../felles/SkjemaGruppe'
+import { Panel } from '~components/felles/Panel'
 
 interface Props {
     lengde: number
@@ -32,7 +33,7 @@ const SelvstendigInfokort = memo(({ lengde, index, fjern }: Props) => {
     })
 
     return (
-        <>
+        <Panel borderColor={'border-info'} borderWidth={'0 0 0 4'} background={'surface-selected'}>
             <SkjemaGruppe>
                 <RHFInput
                     name={`${selvstendigName}.beskrivelse` as const}
@@ -55,7 +56,9 @@ const SelvstendigInfokort = memo(({ lengde, index, fjern }: Props) => {
 
             <SkjemaGruppe>
                 <Label>{t('merOmSituasjonenDin.selvstendig.arbeidsmengde')}</Label>
-                <BodyShort textColor="subtle">{t('merOmSituasjonenDin.selvstendig.arbeidsmengde.beskrivelse')}</BodyShort>
+                <BodyShort textColor="subtle">
+                    {t('merOmSituasjonenDin.selvstendig.arbeidsmengde.beskrivelse')}
+                </BodyShort>
                 <SkjemaElement>
                     <NumberSelectRad>
                         <RHFNumberInput
@@ -102,13 +105,13 @@ const SelvstendigInfokort = memo(({ lengde, index, fjern }: Props) => {
             </SkjemaElement>
 
             {lengde > 1 && (
-                <div style={{ textAlign: 'right' }}>
+                <div>
                     <Button variant={'secondary'} type={'button'} onClick={() => fjern(index)}>
                         <DeleteFilled /> &nbsp;{t('knapp.fjern')}
                     </Button>
                 </div>
             )}
-        </>
+        </Panel>
     )
 })
 

--- a/apps/omstillingsstoenad-ui/src/components/soknad/7-barnepensjon/LeggTilBarnSkjema.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/soknad/7-barnepensjon/LeggTilBarnSkjema.tsx
@@ -189,7 +189,7 @@ const LeggTilBarnSkjema = ({ avbryt, lagre, barn, fnrRegistrerteBarn }: Props) =
             </SkjemaElement>
             <FormProvider {...methods}>
                 <form onSubmit={(e) => e.preventDefault()} autoComplete={isDev ? 'on' : 'off'}>
-                    <EndreBarnKort borderRadius padding={'0'} borderColor={'border-default'} borderWidth={'0'}>
+                    <EndreBarnKort borderRadius padding={'0'} borderColor={'border-default'} borderWidth={'1'}>
                         <EndreBarnKortHeader>
                             <img alt="barn" src={ikon} />
                             <Heading size={'small'} className={'overskrift'}>
@@ -450,7 +450,7 @@ const LeggTilBarnSkjema = ({ avbryt, lagre, barn, fnrRegistrerteBarn }: Props) =
                                                             <Panel
                                                                 borderRadius
                                                                 borderColor={'border-default'}
-                                                                borderWidth={'0'}
+                                                                borderWidth={'1'}
                                                             >
                                                                 <Alert
                                                                     variant={'info'}

--- a/apps/omstillingsstoenad-ui/src/components/soknad/7-barnepensjon/LeggTilBarnSkjema.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/soknad/7-barnepensjon/LeggTilBarnSkjema.tsx
@@ -189,7 +189,7 @@ const LeggTilBarnSkjema = ({ avbryt, lagre, barn, fnrRegistrerteBarn }: Props) =
             </SkjemaElement>
             <FormProvider {...methods}>
                 <form onSubmit={(e) => e.preventDefault()} autoComplete={isDev ? 'on' : 'off'}>
-                    <EndreBarnKort border padding={'0'}>
+                    <EndreBarnKort borderRadius padding={'0'} borderColor={'border-default'} borderWidth={'0'}>
                         <EndreBarnKortHeader>
                             <img alt="barn" src={ikon} />
                             <Heading size={'small'} className={'overskrift'}>
@@ -447,7 +447,11 @@ const LeggTilBarnSkjema = ({ avbryt, lagre, barn, fnrRegistrerteBarn }: Props) =
                                                                     valgfri
                                                                 />
                                                             </SkjemaElement>
-                                                            <Panel border>
+                                                            <Panel
+                                                                borderRadius
+                                                                borderColor={'border-default'}
+                                                                borderWidth={'0'}
+                                                            >
                                                                 <Alert
                                                                     variant={'info'}
                                                                     className={'navds-alert--inline'}

--- a/apps/omstillingsstoenad-ui/src/components/soknad/7-barnepensjon/LeggTilBarnSkjema.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/soknad/7-barnepensjon/LeggTilBarnSkjema.tsx
@@ -189,7 +189,7 @@ const LeggTilBarnSkjema = ({ avbryt, lagre, barn, fnrRegistrerteBarn }: Props) =
             </SkjemaElement>
             <FormProvider {...methods}>
                 <form onSubmit={(e) => e.preventDefault()} autoComplete={isDev ? 'on' : 'off'}>
-                    <EndreBarnKort borderRadius padding={'0'} borderColor={'border-default'} borderWidth={'1'}>
+                    <EndreBarnKort border padding={'0'}>
                         <EndreBarnKortHeader>
                             <img alt="barn" src={ikon} />
                             <Heading size={'small'} className={'overskrift'}>
@@ -447,11 +447,7 @@ const LeggTilBarnSkjema = ({ avbryt, lagre, barn, fnrRegistrerteBarn }: Props) =
                                                                     valgfri
                                                                 />
                                                             </SkjemaElement>
-                                                            <Panel
-                                                                borderRadius
-                                                                borderColor={'border-default'}
-                                                                borderWidth={'1'}
-                                                            >
+                                                            <Panel border>
                                                                 <Alert
                                                                     variant={'info'}
                                                                     className={'navds-alert--inline'}


### PR DESCRIPTION
Gjenbruker designet til fyllut

Bodd eller arbeidet i utlandet
<img width="506" alt="Skjermbilde 2024-10-20 kl  19 13 10" src="https://github.com/user-attachments/assets/2b8aa9da-ca3e-4dcb-8b9d-3b68d7cdd8dc">
<img width="520" alt="Skjermbilde 2024-10-20 kl  19 13 19" src="https://github.com/user-attachments/assets/a8dd7726-cf1d-497e-adfc-2f3596576ef7">

Samboer (Denne fikk samme design da den var lik de andre før)
<img width="520" alt="Skjermbilde 2024-10-20 kl  19 41 25" src="https://github.com/user-attachments/assets/13e26078-eb61-4a06-9236-45304bcf4409">

Arbeidstaker
<img width="534" alt="Skjermbilde 2024-10-20 kl  19 49 17" src="https://github.com/user-attachments/assets/4d4b5216-c971-4186-a8a5-a71e463f6376">
<img width="507" alt="Skjermbilde 2024-10-20 kl  19 49 24" src="https://github.com/user-attachments/assets/707a3bb2-b082-4e6f-b627-cad281fc3b5c">

Selvstendig næringsdrivende
<img width="521" alt="Skjermbilde 2024-10-20 kl  19 51 03" src="https://github.com/user-attachments/assets/fcee5f92-c028-4ab1-bc65-12c7be1a75df">
<img width="514" alt="Skjermbilde 2024-10-20 kl  19 51 23" src="https://github.com/user-attachments/assets/fe2306b2-db61-4af4-8890-e35001b8df3f">
