### PR TITLE
EY-4558: Bytt ut formprogress i BP

### DIFF
--- a/apps/barnepensjon-ui/src/components/application/Dialogue.tsx
+++ b/apps/barnepensjon-ui/src/components/application/Dialogue.tsx
@@ -1,11 +1,10 @@
 import { Route, Routes, useLocation, useNavigate } from 'react-router-dom'
 import { StepType } from '../../utils/steps'
-import { FormProgress } from '@navikt/ds-react'
 import { v4 as uuid } from 'uuid'
 import React, { useState } from 'react'
 import { ActionTypes } from '../../context/application/application'
 import PageNotFound from '../error/PageNotFound'
-import useTranslation from '../../hooks/useTranslation'
+import FormProgress from '~components/common/FormProgress'
 
 interface DialogueProps {
     steps: StepType[]
@@ -19,8 +18,6 @@ export interface StepProps {
 }
 
 export default function Dialogue({ steps, pathPrefix }: DialogueProps) {
-    const { t } = useTranslation('steps')
-
     const navigate = useNavigate()
     const { pathname } = useLocation()
     const currentIndex = steps.findIndex((step) => pathname.includes(step.path))
@@ -39,16 +36,11 @@ export default function Dialogue({ steps, pathPrefix }: DialogueProps) {
     return (
         <>
             <FormProgress
-                totalSteps={steps.length}
-                activeStep={currentIndex + 1}
-                onStepChange={(step) => visitNavigate(step - 1)}
-            >
-                {steps.map((step: StepType) => (
-                    <FormProgress.Step key={uuid()} interactive={visitedPaths.includes(step)}>
-                        {t(step.label)}
-                    </FormProgress.Step>
-                ))}
-            </FormProgress>
+                activeStep={currentIndex}
+                setStep={visitNavigate}
+                possibleSteps={steps}
+                visitedSteps={visitedPaths}
+            />
 
             <Routes>
                 {steps.map((step: StepType) => (

--- a/apps/barnepensjon-ui/src/components/common/FormProgress.tsx
+++ b/apps/barnepensjon-ui/src/components/common/FormProgress.tsx
@@ -1,0 +1,105 @@
+import { isDev } from '~api/axios'
+import { BodyShort, Button, Heading, Stepper } from '@navikt/ds-react'
+import { v4 as uuid } from 'uuid'
+import styled from 'styled-components'
+import { useState } from 'react'
+import { Collapse, Expand } from '@navikt/ds-icons'
+import { StepType } from '~utils/steps'
+import useTranslation from '~hooks/useTranslation'
+
+interface Props {
+    activeStep: number
+    setStep: (value: number) => void
+    possibleSteps: StepType[]
+    visitedSteps: StepType[]
+}
+
+const ProgressBar = styled.div<{ $prosess: string; $lastStep: boolean }>`
+    height: 1rem;
+    background-color: var(--a-surface-neutral-subtle);
+    color: var(--a-surface-alt-3);
+    border-radius: 1rem;
+    margin-bottom: 0.5rem;
+    box-shadow:
+        inset 0 1px 3px #00000026,
+        inset 0 0 1px #0003;
+    span {
+        background-color: var(--a-surface-alt-3);
+        height: 1rem;
+        display: block;
+        width: ${(props) => props.$prosess};
+        border-radius: inherit;
+    }
+`
+
+const FlexSpaceBetween = styled.div`
+    display: flex;
+
+    button {
+        width: 100%;
+        padding: 0.5rem 2px 0.5rem 0;
+        justify-content: space-between;
+    }
+`
+
+const FormProgressHeader = styled(Heading)`
+    padding-bottom: 0.5rem;
+    padding-top: 0.5rem;
+`
+
+const FormProgress = ({ activeStep, setStep, possibleSteps, visitedSteps }: Props) => {
+    const [isOpen, setIsOpen] = useState(false)
+
+    const { t } = useTranslation('steps')
+
+    const activePage = activeStep + 1
+    const progress = `${(100 / possibleSteps.length) * activePage}%`
+    const stepName = t(possibleSteps[activeStep].label)
+    const stepOverview = t('step', { activePage: String(activePage), possibleStep: String(possibleSteps.length) })
+
+    return (
+        <>
+            {isDev ? (
+                <FlexSpaceBetween>
+                    <Button
+                        variant={'tertiary-neutral'}
+                        icon={isOpen ? <Collapse fontSize={24} aria-hidden /> : <Expand fontSize={24} aria-hidden />}
+                        onClick={() => setIsOpen(!isOpen)}
+                        iconPosition={'right'}
+                        aria-label={`${stepName} - ${stepOverview} - Klikk for å ${
+                            isOpen ? 'lukke' : 'åpne'
+                        } oversikt over stegene`}
+                    >
+                        <Heading size={'small'}>{stepName}</Heading>
+                    </Button>
+                </FlexSpaceBetween>
+            ) : (
+                <FormProgressHeader size={'small'}>{stepName}</FormProgressHeader>
+            )}
+            <ProgressBar $prosess={progress} $lastStep={possibleSteps.length === activePage}>
+                <span />
+            </ProgressBar>
+            <BodyShort>{stepOverview}</BodyShort>
+            {isOpen && isDev && (
+                <Stepper
+                    activeStep={activePage}
+                    onStepChange={(step) => setStep(step - 1)}
+                    orientation={'vertical'}
+                    interactive={true}
+                >
+                    {possibleSteps.map((steg, index) => (
+                        <Stepper.Step
+                            key={uuid()}
+                            completed={index < activeStep}
+                            interactive={visitedSteps.includes(steg)}
+                        >
+                            {t(steg.label)}
+                        </Stepper.Step>
+                    ))}
+                </Stepper>
+            )}
+        </>
+    )
+}
+
+export default FormProgress

--- a/apps/barnepensjon-ui/src/locales/en.ts
+++ b/apps/barnepensjon-ui/src/locales/en.ts
@@ -584,6 +584,7 @@ const steps = {
     YourSituation: 'Your situation',
     AboutChildren: 'Information about the children',
     Summary: 'Summary',
+    step: 'Step {activePage} of {possibleStep}',
 }
 
 const texts: Record<TNamespace, Record<TKey, Translation>> = {

--- a/apps/barnepensjon-ui/src/locales/nb.ts
+++ b/apps/barnepensjon-ui/src/locales/nb.ts
@@ -572,6 +572,7 @@ const steps = {
     YourSituation: 'Din situasjon',
     AboutChildren: 'Opplysninger om barna',
     Summary: 'Oppsummering',
+    step: 'Steg {activePage} av {possibleStep}',
 }
 
 const texts: Record<TNamespace, Record<TKey, Translation>> = {

--- a/apps/barnepensjon-ui/src/locales/nn.ts
+++ b/apps/barnepensjon-ui/src/locales/nn.ts
@@ -569,6 +569,7 @@ const steps = {
     YourSituation: 'Din situasjon',
     AboutChildren: 'Opplysningar om barna',
     Summary: 'Oppsummering',
+    step: 'Steg {activePage} av {possibleStep}',
 }
 
 const texts: Record<TNamespace, Record<TKey, Translation>> = {

--- a/apps/omstillingsstoenad-ui/src/components/felles/Stegviser.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/felles/Stegviser.tsx
@@ -16,16 +16,19 @@ interface Props {
 
 const ProgressBar = styled.div<{ $prosess: string; $lastStep: boolean }>`
     height: 1rem;
-    background-color: #cce2f0;
-    color: #66a3c4;
+    background-color: var(--a-surface-neutral-subtle);
+    color: var(--a-surface-alt-3);
     border-radius: 1rem;
     margin-bottom: 0.5rem;
+    box-shadow:
+        inset 0 1px 3px #00000026,
+        inset 0 0 1px #0003;
     span {
-        background-color: #66a3c4;
+        background-color: var(--a-surface-alt-3);
         height: 1rem;
         display: block;
         width: ${(props) => props.$prosess};
-        border-radius: ${(props) => (props.$lastStep ? '1rem' : '1rem 0 0 1rem')};
+        border-radius: inherit;
     }
 `
 


### PR DESCRIPTION
Siden vi ikke støtter lagring ved navigering fra formprogress, så byttes vi ut med den vi har i oms der det kun er lov å navigere når man er i dev. Ha endret fargene til å matche Aksel sin FormProgress

Dette viser hvordan det blir i prod
<img width="338" alt="Skjermbilde 2024-10-27 kl  12 58 07" src="https://github.com/user-attachments/assets/2be5400a-9307-4e5e-9f77-1faab352b4b6">
