### PR TITLE
logEvent uten eventdata tar ikke med innebygd Amplitude logging,

### DIFF
--- a/apps/barnepensjon-ui/src/components/application/summary/Summary.tsx
+++ b/apps/barnepensjon-ui/src/components/application/summary/Summary.tsx
@@ -63,7 +63,7 @@ export default function Summary({ prev }: StepProps) {
             .catch((e: Error) => {
                 setLoading(false)
                 setIsOpen(false)
-                logEvent(LogEvents.SEND_APPLICATION_ERROR)
+                logEvent(LogEvents.SEND_APPLICATION_ERROR, { type: SoeknadType.BARNEPENSJON })
 
                 if (e.message === 'FERDIGSTILT') setError(t('errorFromConflict'))
                 else setError(t('errorWhenSending'))
@@ -154,11 +154,7 @@ export default function Summary({ prev }: StepProps) {
                 </Modal.Header>
 
                 <Modal.Body>
-                    {loading ? (
-                        <Loader size={'xlarge'} />
-                    ) : (
-                        <BodyShortMuted>{t('sendApplicationBody')}</BodyShortMuted>
-                    )}
+                    {loading ? <Loader size={'xlarge'} /> : <BodyShortMuted>{t('sendApplicationBody')}</BodyShortMuted>}
                 </Modal.Body>
                 {!loading && (
                     <NavRow>

--- a/apps/barnepensjon-ui/src/components/error/SystemUnavailable.tsx
+++ b/apps/barnepensjon-ui/src/components/error/SystemUnavailable.tsx
@@ -7,6 +7,7 @@ import { useEffect } from 'react'
 import FormElement from '../common/FormElement'
 import styled from 'styled-components'
 import blomstHjerteHus from '../../assets/blomstHjerteHus.svg'
+import { SoeknadType } from '~api/dto/InnsendtSoeknad'
 
 const Icon = styled.img`
     height: 4rem;
@@ -21,7 +22,7 @@ export default function SystemUnavailable() {
     const { logEvent } = useAmplitude()
 
     useEffect(() => {
-        logEvent(LogEvents.SYSTEM_UNAVAILABLE)
+        logEvent(LogEvents.SYSTEM_UNAVAILABLE, { type: SoeknadType.BARNEPENSJON })
     }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
     const retry = () => {

--- a/apps/barnepensjon-ui/src/hooks/useAmplitude.ts
+++ b/apps/barnepensjon-ui/src/hooks/useAmplitude.ts
@@ -45,12 +45,15 @@ export const useAmplitude = () => {
 
     useEffect(() => {
         if (prevLocation?.pathname !== location?.pathname) {
-            logEvent(LogEvents.PAGE_CHANGE)
+            logEvent(LogEvents.PAGE_CHANGE, {
+                prevLocation: prevLocation?.pathname,
+                newLocation: location?.pathname,
+            })
         }
         setPrevLocation(location)
     }, [location]) // eslint-disable-line react-hooks/exhaustive-deps
 
-    const logEvent = (eventName: LogEvents, eventData?: any): void => {
+    const logEvent = (eventName: LogEvents, eventData: any): void => {
         setTimeout(() => {
             try {
                 if (amplitude) {

--- a/apps/omstillingsstoenad-ui/src/hooks/useAmplitude.ts
+++ b/apps/omstillingsstoenad-ui/src/hooks/useAmplitude.ts
@@ -34,12 +34,15 @@ export const useAmplitude = () => {
 
     useEffect(() => {
         if (prevLocation?.pathname !== location?.pathname) {
-            logEvent(LogEvents.SIDEVISNING)
+            logEvent(LogEvents.SIDEVISNING, {
+                prevLocation: prevLocation?.pathname,
+                newLocation: location?.pathname,
+            })
         }
         setPrevLocation(location)
     }, [location])
 
-    const logEvent = (eventName: LogEvents, eventData?: any): void => {
+    const logEvent = (eventName: LogEvents, eventData: any): void => {
         setTimeout(() => {
             try {
                 if (amplitude) {


### PR DESCRIPTION
så gjør det påkrevd for å alltid ha med det man får gratis fra Amplitude