### PR TITLE
Oversettelse formprogress barnepensjon

### DIFF
--- a/apps/barnepensjon-ui/src/components/application/Dialogue.tsx
+++ b/apps/barnepensjon-ui/src/components/application/Dialogue.tsx
@@ -43,6 +43,11 @@ export default function Dialogue({ steps, pathPrefix }: DialogueProps) {
                 activeStep={currentIndex + 1}
                 onStepChange={(step) => visitNavigate(step - 1)}
                 interactiveSteps={false}
+                translations={{
+                    step: t('Step', { activePage: String(currentIndex + 1), totalPages: String(steps.length) }),
+                    showAllSteps: t('showAllSteps'),
+                    hideAllSteps: t('hideAllSteps'),
+                }}
             >
                 {steps.map((step: StepType) => (
                     <FormProgress.Step key={uuid()}>{t(step.label)}</FormProgress.Step>

--- a/apps/barnepensjon-ui/src/locales/en.ts
+++ b/apps/barnepensjon-ui/src/locales/en.ts
@@ -587,6 +587,9 @@ const steps = {
     YourSituation: 'Your situation',
     AboutChildren: 'Information about the children',
     Summary: 'Summary',
+    Step: 'Step {activePage} of {totalPages}',
+    showAllSteps: 'Show all steps',
+    hideAllSteps: 'Hide all steps',
 }
 
 const texts: Record<TNamespace, Record<TKey, Translation>> = {

--- a/apps/barnepensjon-ui/src/locales/nb.ts
+++ b/apps/barnepensjon-ui/src/locales/nb.ts
@@ -575,6 +575,9 @@ const steps = {
     YourSituation: 'Din situasjon',
     AboutChildren: 'Opplysninger om barna',
     Summary: 'Oppsummering',
+    Step: 'Steg {activePage} av {totalPages}',
+    showAllSteps: 'Vis alle steg',
+    hideAllSteps: 'Skjul alle steg',
 }
 
 const texts: Record<TNamespace, Record<TKey, Translation>> = {

--- a/apps/barnepensjon-ui/src/locales/nn.ts
+++ b/apps/barnepensjon-ui/src/locales/nn.ts
@@ -572,6 +572,9 @@ const steps = {
     YourSituation: 'Din situasjon',
     AboutChildren: 'Opplysningar om barna',
     Summary: 'Oppsummering',
+    Step: 'Steg {activePage} av {totalPages}',
+    showAllSteps: 'Vis alle steig',
+    hideAllSteps: 'Skjul alle steig',
 }
 
 const texts: Record<TNamespace, Record<TKey, Translation>> = {


### PR DESCRIPTION
Formprogress er på bokmål for alle språk i barnepensjon, så har lagt til oversettelser for nynorsk og engelsk