### PR TITLE
Legg til skjema som path for selvbetjening

### DIFF
--- a/apps/etterlatte-node-server/package.json
+++ b/apps/etterlatte-node-server/package.json
@@ -42,7 +42,7 @@
     "start:bp": "BASE_PATH=/barnepensjon/soknad yarn start:mock",
     "start:oms": "BASE_PATH=/omstillingsstonad/soknad yarn start:mock",
     "start:mock": "ts-node-dev --project ./tsconfig.json src/mock/mock-server.ts",
-    "start:selvbetjening": "BASE_PATH=/omstillingsstonad/inntekt yarn start:mock-selvbetjening",
+    "start:selvbetjening": "BASE_PATH=/omstillingsstonad/skjema yarn start:mock-selvbetjening",
     "start:mock-selvbetjening": "ts-node-dev --project ./tsconfig.json src/mock/mock-server-selvbetjening.ts",
     "build": "NODE_ENV=production tsc --project ./tsconfig.json",
     "build-dev": "NODE_ENV=dev tsc --project ./tsconfig.json",

--- a/apps/selvbetjening-ui/.nais/dev.yaml
+++ b/apps/selvbetjening-ui/.nais/dev.yaml
@@ -13,16 +13,16 @@ spec:
     max: 2
     cpuThresholdPercentage: 90
   ingresses:
-    - https://etterlatte.intern.dev.nav.no/omstillingsstonad/inntekt
-    - https://etterlatte.ekstern.dev.nav.no/omstillingsstonad/inntekt
+    - https://etterlatte.intern.dev.nav.no/omstillingsstonad/skjema
+    - https://etterlatte.ekstern.dev.nav.no/omstillingsstonad/skjema
   liveness:
-    path: /omstillingsstonad/isAlive
+    path: /omstillingsstonad/skjema/isAlive
     initialDelay: 10
     timeout: 5
     periodSeconds: 5
     failureThreshold: 30
   readiness:
-    path: /omstillingsstonad/inntekt/isReady
+    path: /omstillingsstonad/skjema/isReady
     initialDelay: 30
     periodSeconds: 5
     timeout: 5
@@ -35,7 +35,7 @@ spec:
       memory: 192Mi
   prometheus:
     enabled: true
-    path: /omstillingsstonad/inntekt/metrics
+    path: /omstillingsstonad/skjema/metrics
   observability:
     autoInstrumentation:
       enabled: true
@@ -54,13 +54,13 @@ spec:
       locale: nb
       autoLogin: true
       autoLoginIgnorePaths:
-        - /omstillingsstonad/inntekt/internal/**
+        - /omstillingsstonad/skjema/internal/**
   envFrom:
     - secret: selvbetjening-ui-sanity
     - secret: my-application-unleash-api-token
   env:
     - name: BASE_PATH
-      value: /omstillingsstonad/inntekt
+      value: /omstillingsstonad/skjema
     - name: API_URL
       value: http://selvbetjening-backend
     - name: AUDIENCE

--- a/apps/selvbetjening-ui/.nais/prod.yaml
+++ b/apps/selvbetjening-ui/.nais/prod.yaml
@@ -13,16 +13,16 @@ spec:
     max: 2
     cpuThresholdPercentage: 90
   ingresses:
-    - https://www.nav.no/inntekt/omstillingsstonad
-    - https://etterlatte.intern.nav.no/inntekt/omstillingsstonad
+    - https://www.nav.no/omstillingsstonad/skjema
+    - https://etterlatte.intern.nav.no/omstillingsstonad/skjema
   liveness:
-    path: /omstillingsstonad/inntekt/isAlive
+    path: /omstillingsstonad/skjema/isAlive
     initialDelay: 10
     timeout: 5
     periodSeconds: 5
     failureThreshold: 30
   readiness:
-    path: /omstillingsstonad/inntekt/isReady
+    path: /omstillingsstonad/skjema/isReady
     initialDelay: 30
     periodSeconds: 5
     timeout: 5
@@ -35,7 +35,7 @@ spec:
       memory: 192Mi
   prometheus:
     enabled: true
-    path: /omstillingsstonad/inntekt/metrics
+    path: /omstillingsstonad/skjema/metrics
   observability:
     autoInstrumentation:
       enabled: true
@@ -54,13 +54,13 @@ spec:
       locale: nb
       autoLogin: true
       autoLoginIgnorePaths:
-        - /omstillingsstonad/inntekt/internal/**
+        - /omstillingsstonad/skjema/internal/**
   envFrom:
     - secret: selvbetjening-ui-sanity
     - secret: my-application-unleash-api-token
   env:
     - name: BASE_PATH
-      value: /omstillingsstonad/inntekt
+      value: /omstillingsstonad/skjema
     - name: API_URL
       value: http://selvbetjening-backend
     - name: AUDIENCE

--- a/apps/selvbetjening-ui/cypress/e2e/spec.cy.js
+++ b/apps/selvbetjening-ui/cypress/e2e/spec.cy.js
@@ -1,5 +1,5 @@
 describe('template spec', () => {
     it('passes', () => {
-        cy.visit('http://localhost:5173/omstillingsstonad/inntekt/innledning')
+        cy.visit('http://localhost:5173/omstillingsstonad/skjema/inntekt/innledning')
     })
 })

--- a/apps/selvbetjening-ui/package.json
+++ b/apps/selvbetjening-ui/package.json
@@ -4,8 +4,8 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "start": "vite --base /omstillingsstonad/inntekt",
-    "build": "tsc && yarn eslint && vite build --outDir build --base /omstillingsstonad/inntekt && yarn lisenssjekk",
+    "start": "vite --base /omstillingsstonad/skjema",
+    "build": "tsc && yarn eslint && vite build --outDir build --base /omstillingsstonad/skjema && yarn lisenssjekk",
     "test": "vitest",
     "cy:test": "TZ=Europe/Oslo cypress run",
     "cy:open": "TZ=Europe/Oslo cypress open",

--- a/apps/selvbetjening-ui/src/inntektsjustering/InntektjusteringRoot.tsx
+++ b/apps/selvbetjening-ui/src/inntektsjustering/InntektjusteringRoot.tsx
@@ -37,7 +37,7 @@ const router = createBrowserRouter(
             ],
         },
     ],
-    { basename: '/omstillingsstonad/inntekt' }
+    { basename: '/omstillingsstonad/skjema/inntekt' }
 )
 
 export const InntektsjusteringRoot = () => {

--- a/apps/selvbetjening-ui/src/meldInnEndring/MeldInnEndringRoot.tsx
+++ b/apps/selvbetjening-ui/src/meldInnEndring/MeldInnEndringRoot.tsx
@@ -19,12 +19,12 @@ const router = createBrowserRouter(
             ],
         },
     ],
-    { basename: '/omstillingsstonad/meld-inn-endring' }
+    { basename: '/omstillingsstonad/skjema/meld-inn-endring' }
 )
 
 export const MeldInnEndringRoot = () => {
     // TODO: denne vil bli erstattet med unleash feature toggle i neste PR
-    const [skalVise] = useState<boolean>(false)
+    const [skalVise] = useState<boolean>(true)
 
     return skalVise && <RouterProvider router={router} />
 }

--- a/apps/selvbetjening-ui/src/meldInnEndring/MeldInnEndringRoot.tsx
+++ b/apps/selvbetjening-ui/src/meldInnEndring/MeldInnEndringRoot.tsx
@@ -24,7 +24,7 @@ const router = createBrowserRouter(
 
 export const MeldInnEndringRoot = () => {
     // TODO: denne vil bli erstattet med unleash feature toggle i neste PR
-    const [skalVise] = useState<boolean>(true)
+    const [skalVise] = useState<boolean>(false)
 
     return skalVise && <RouterProvider router={router} />
 }


### PR DESCRIPTION
Var litt issues med ingressen når jeg satt den til å være www.nav.no/omstillingsstonad. Som f.eks at produktsiden ble overridet.

Når har skjemaene i selvbetjening fått ingressen www.nav.no/omstillingsstonad/skjema