### PR TITLE
Inntektsendring proeve sendte foerst

### DIFF
--- a/apps/selvbetjening-backend/src/main/kotlin/jobs/PubliserInntektsjusteringJobb.kt
+++ b/apps/selvbetjening-backend/src/main/kotlin/jobs/PubliserInntektsjusteringJobb.kt
@@ -74,12 +74,12 @@ class PubliserInntektsjusteringJobb(
                 return
             }
 
-            nyeInntektsjusteringer.forEach { publiser(it) }
-
             val forsoekteInntektsjusteringer =
                 inntektsjusteringService.hentInntektsjusteringForStatus(
                     InntektsjusteringStatus.SENDT,
                 )
+
+            nyeInntektsjusteringer.forEach { publiser(it) }
 
             forsoekteInntektsjusteringer.forEach {
                 logger.warn("Inntektjustering tidligere sendt til Gjenny sendes på nytt med id=${it.id}")

--- a/apps/selvbetjening-backend/src/main/kotlin/jobs/PubliserInntektsjusteringJobb.kt
+++ b/apps/selvbetjening-backend/src/main/kotlin/jobs/PubliserInntektsjusteringJobb.kt
@@ -20,6 +20,7 @@ enum class InntektjusteringToggles(
     val value: String,
 ) : FeatureToggle {
     PUBLISER_MOTTATTE_INNTEKTSJUSTERINGER("publiser-mottatte-inntektsjusteringer"),
+    PUBLISER_KUN_EN_INNTEKTSJUSTERING("publiser-kun-en-inntektsjustering"),
     ;
 
     override fun key(): String = this.value
@@ -62,6 +63,17 @@ class PubliserInntektsjusteringJobb(
                 inntektsjusteringService.hentInntektsjusteringForStatus(
                     InntektsjusteringStatus.LAGRET,
                 )
+
+            // Kun midlertidig for å verifisere at fungerer et par ganger i  prod
+            if (featureToggleService.isEnabled(
+                    InntektjusteringToggles.PUBLISER_MOTTATTE_INNTEKTSJUSTERINGER,
+                    defaultValue = false,
+                )
+            ) {
+                publiser(nyeInntektsjusteringer.first())
+                return
+            }
+
             nyeInntektsjusteringer.forEach { publiser(it) }
 
             val forsoekteInntektsjusteringer =


### PR DESCRIPTION
1. Endret til å hendte alle som tidligere har status sendt før nye sendes slik at de ikke sendes på nytt med en gang
2. Midlertidig bryter for å kunne sende en inntektsendring av gangen for å verifiser ei prod