### PR TITLE
EY-4841: Fjern frivillig skattetrekk

### DIFF
--- a/apps/barnepensjon-ui/cypress/support/commands.ts
+++ b/apps/barnepensjon-ui/cypress/support/commands.ts
@@ -89,8 +89,6 @@ Cypress.Commands.add('addChild', (gotoNext: boolean = false) => {
     cy.get('.navds-confirmation-panel').find('[type="checkbox"]').check()
     cy.get('#accountTypeSelection').get('[value="NORSK"]').check({ force: true })
     cy.get('.navds-form-field:contains("Oppgi norsk kontonummer")').find('input').type('1201.05.0101011')
-    cy.get('#taxWithholdAnswer').find('[type="radio"]').check({ force: true })
-    cy.get('.navds-fieldset:contains("skattetrekk")').find('input').last().type('22', { force: true })
 
     cy.clickBtn(Button.Add)
 

--- a/apps/barnepensjon-ui/src/api/dto/FellesOpplysninger.ts
+++ b/apps/barnepensjon-ui/src/api/dto/FellesOpplysninger.ts
@@ -49,13 +49,6 @@ export interface UtbetalingsInformasjon {
     utenlandskBankAdresse?: Opplysning<FritekstSvar>
     iban?: Opplysning<FritekstSvar>
     swift?: Opplysning<FritekstSvar>
-    skattetrekk?: SkatteTrekk
-}
-
-export interface SkatteTrekk {
-    svar: Opplysning<EnumSvar<JaNeiVetIkke>>
-    trekk?: Opplysning<FritekstSvar>
-    beskrivelse?: Opplysning<FritekstSvar>
 }
 
 export interface Kontaktinfo {
@@ -65,11 +58,6 @@ export interface Kontaktinfo {
 export enum BankkontoType {
     NORSK = 'NORSK',
     UTENLANDSK = 'UTENLANDSK',
-}
-
-export enum KronerEllerProsentType {
-    KRONER = 'KRONER',
-    PROSENT = 'PROSENT',
 }
 
 export enum OppholdUtlandType {

--- a/apps/barnepensjon-ui/src/api/dto/mapper.test.ts
+++ b/apps/barnepensjon-ui/src/api/dto/mapper.test.ts
@@ -350,9 +350,5 @@ const createChild = (firstName: string, lastName: string, fnrDnr: string): IChil
     paymentDetails: {
         accountType: BankkontoType.NORSK,
         bankAccount: '1233.22.12332',
-        taxWithhold: {
-            answer: JaNeiVetIkke.JA,
-            taxPercentage: '21%',
-        },
     },
 })

--- a/apps/barnepensjon-ui/src/api/dto/soeknadMapper.ts
+++ b/apps/barnepensjon-ui/src/api/dto/soeknadMapper.ts
@@ -8,10 +8,8 @@ import {
     BetingetOpplysning,
     EnumSvar,
     JaNeiVetIkke,
-    KronerEllerProsentType,
     OppholdUtland,
     Opplysning,
-    SkatteTrekk,
     UtbetalingsInformasjon,
     Utenlandsadresse,
 } from './FellesOpplysninger'
@@ -109,47 +107,6 @@ const mapUtbetalingsinfo = (
             },
         }
     } else if (!!person.paymentDetails?.bankAccount) {
-        let skattetrekk: SkatteTrekk | undefined
-        if (person.paymentDetails?.taxWithhold?.answer === JaNeiVetIkke.JA) {
-            skattetrekk = {
-                svar: {
-                    spoersmaal: t('doYouWantUsToWithholdTax', { ns: 'paymentDetails' }),
-                    svar: {
-                        verdi: person.paymentDetails.taxWithhold.answer,
-                        innhold: t(person.paymentDetails.taxWithhold.answer, { ns: 'radiobuttons' }),
-                    },
-                },
-                trekk:
-                    person.paymentDetails.taxWithhold.type! === KronerEllerProsentType.KRONER
-                        ? {
-                              spoersmaal: t('desiredTaxKroner', { ns: 'paymentDetails' }),
-                              svar: {
-                                  innhold:
-                                      person.paymentDetails.taxWithhold.taxPercentage! +
-                                      ' ' +
-                                      t(person.paymentDetails.taxWithhold.type!),
-                              },
-                          }
-                        : {
-                              spoersmaal: t('desiredTaxPercentage', { ns: 'paymentDetails' }),
-                              svar: {
-                                  innhold:
-                                      person.paymentDetails.taxWithhold.taxPercentage! +
-                                      ' ' +
-                                      t(person.paymentDetails.taxWithhold.type!),
-                              },
-                          },
-                beskrivelse: person.paymentDetails.taxWithhold.description!
-                    ? {
-                          spoersmaal: t('taxPercentageDescription', { ns: 'paymentDetails' }),
-                          svar: {
-                              innhold: person.paymentDetails.taxWithhold.description!,
-                          },
-                      }
-                    : undefined,
-            }
-        }
-
         return {
             spoersmaal: t('accountType', { ns: 'paymentDetails' }),
             svar: {
@@ -163,7 +120,6 @@ const mapUtbetalingsinfo = (
                         innhold: person.paymentDetails.bankAccount!,
                     },
                 },
-                skattetrekk,
             },
         }
     } else return undefined

--- a/apps/barnepensjon-ui/src/assets/mocks/mock-child-single-dead.json
+++ b/apps/barnepensjon-ui/src/assets/mocks/mock-child-single-dead.json
@@ -12,10 +12,7 @@
         "residesInNorway": "JA",
         "paymentDetails": {
             "accountType": "NORSK",
-            "bankAccount": "1231.23.12312",
-            "taxWithhold": {
-                "answer": "NEI"
-            }
+            "bankAccount": "1231.23.12312"
         }
     },
     "secondParent": {

--- a/apps/barnepensjon-ui/src/assets/mocks/mock-child.json
+++ b/apps/barnepensjon-ui/src/assets/mocks/mock-child.json
@@ -12,10 +12,7 @@
         "residesInNorway": "JA",
         "paymentDetails": {
             "accountType": "NORSK",
-            "bankAccount": "1231.23.12312",
-            "taxWithhold": {
-                "answer": "NEI"
-            }
+            "bankAccount": "1231.23.12312"
         }
     },
     "firstParent": {

--- a/apps/barnepensjon-ui/src/assets/mocks/mock-guardian.json
+++ b/apps/barnepensjon-ui/src/assets/mocks/mock-guardian.json
@@ -55,10 +55,6 @@
         "appliesForChildrensPension": true,
         "paymentDetails": {
           "accountType": "NORSK",
-          "taxWithhold": {
-            "answer": "JA",
-            "taxPercentage": "12"
-          },
           "bankAccount": "1231.23.12312"
         }
       }

--- a/apps/barnepensjon-ui/src/assets/mocks/mock-parent.json
+++ b/apps/barnepensjon-ui/src/assets/mocks/mock-parent.json
@@ -54,10 +54,6 @@
         "appliesForChildrensPension": true,
         "paymentDetails": {
           "accountType": "NORSK",
-          "taxWithhold": {
-            "answer": "JA",
-            "taxPercentage": "22"
-          },
           "bankAccount": "1231.23.12312"
         }
       }

--- a/apps/barnepensjon-ui/src/components/application/summary/fragments/PaymentDetailsSummary.tsx
+++ b/apps/barnepensjon-ui/src/components/application/summary/fragments/PaymentDetailsSummary.tsx
@@ -1,12 +1,12 @@
-import { BankkontoType, KronerEllerProsentType } from '../../../../api/dto/FellesOpplysninger'
+import { BankkontoType } from '../../../../api/dto/FellesOpplysninger'
 import useTranslation from '../../../../hooks/useTranslation'
-import { TextGroup, TextGroupJaNeiVetIkke } from '../TextGroup'
+import { TextGroup } from '../TextGroup'
 import { IPaymentDetails } from '../../../../types/person'
 
 export default function PaymentDetailsSummary({ paymentDetails }: { paymentDetails: IPaymentDetails }) {
     const { t } = useTranslation('paymentDetails')
 
-    const { accountType, bankAccount, taxWithhold, foreignBankName, foreignBankAddress, iban, swift } = paymentDetails
+    const { accountType, bankAccount, foreignBankName, foreignBankAddress, iban, swift } = paymentDetails
 
     return (
         <>
@@ -19,28 +19,6 @@ export default function PaymentDetailsSummary({ paymentDetails }: { paymentDetai
                     <TextGroup title={t('foreignBankAddress')} content={foreignBankAddress} />
                     <TextGroup title={t('iban')} content={iban} />
                     <TextGroup title={t('swift')} content={swift} />
-                </>
-            )}
-
-            {taxWithhold?.answer && (
-                <>
-                    <TextGroupJaNeiVetIkke title={t('doYouWantUsToWithholdTax')} content={taxWithhold.answer} />
-
-                    {taxWithhold.taxPercentage && (
-                        <>
-                            <TextGroup
-                                title={t(
-                                    taxWithhold.type === KronerEllerProsentType.KRONER
-                                        ? 'desiredTaxKroner'
-                                        : 'desiredTaxPercentage'
-                                )}
-                                content={taxWithhold.taxPercentage + ' ' + t(taxWithhold.type!)}
-                            />
-                            {taxWithhold.description && (
-                                <TextGroup title={t('taxPercentageDescription')} content={taxWithhold.description} />
-                            )}
-                        </>
-                    )}
                 </>
             )}
         </>

--- a/apps/barnepensjon-ui/src/components/common/PaymentDetails.tsx
+++ b/apps/barnepensjon-ui/src/components/common/PaymentDetails.tsx
@@ -1,16 +1,16 @@
-import { Alert, BodyShort, Box, Heading, HelpText, Label, Link, RadioProps } from '@navikt/ds-react'
+import { Heading, HelpText, RadioProps } from '@navikt/ds-react'
 import styled from 'styled-components'
-import { BankkontoType, JaNeiVetIkke, KronerEllerProsentType } from '../../api/dto/FellesOpplysninger'
+import { BankkontoType } from '~api/dto/FellesOpplysninger'
 import useTranslation from '../../hooks/useTranslation'
 import FormElement from './FormElement'
-import { RHFGeneralQuestionRadio, RHFRadio } from './rhf/RHFRadio'
-import { RHFBicInput, RHFIbanInput, RHFInput, RHFInputArea, RHFKontonummerInput, RHFNumberInput } from './rhf/RHFInput'
+import { RHFRadio } from './rhf/RHFRadio'
+import { RHFBicInput, RHFIbanInput, RHFInput, RHFKontonummerInput } from './rhf/RHFInput'
 import FormGroup from './FormGroup'
 import { useFormContext } from 'react-hook-form'
-import { IAboutChildren, IAboutYou } from '../../types/person'
-import { Bredde } from '../../utils/bredde'
-import { useApplicationContext } from '../../context/application/ApplicationContext'
-import { ApplicantRole } from '../../types/applicant'
+import { IAboutChildren, IAboutYou } from '~types/person'
+import { Bredde } from '~utils/bredde'
+import { useApplicationContext } from '~context/application/ApplicationContext'
+import { ApplicantRole } from '~types/applicant'
 
 const HelpTextLabel = styled.div`
     display: flex;
@@ -22,8 +22,6 @@ export default function PaymentDetails() {
     const { watch } = useFormContext<IAboutYou | IAboutChildren>()
 
     const accountType = watch('paymentDetails.accountType')
-    const withholdingTaxChildrensPension = watch('paymentDetails.taxWithhold.answer')
-    const withholdingTaxType = watch('paymentDetails.taxWithhold.type')
 
     const isParent = state.applicant?.applicantRole === ApplicantRole.PARENT
 
@@ -50,69 +48,6 @@ export default function PaymentDetails() {
                             htmlSize={Bredde.XS}
                         />
                     </FormElement>
-                    <FormGroup>
-                        <FormElement>
-                            <Label>{t('taxWithholdTitle')}</Label>
-                            <BodyShort spacing>{t('taxWithholdDescription1')}</BodyShort>
-                            <BodyShort spacing>
-                                {t('taxWithholdDescription2')}
-                                <Link href={t('taxWithholdDescription2Href')} inlineText>
-                                    {t('taxWithholdDescription2HrefText')}
-                                </Link>
-                                .
-                            </BodyShort>
-                            <BodyShort spacing>{t('taxWithholdDescription3')}</BodyShort>
-                        </FormElement>
-                        <FormElement>
-                            <RHFGeneralQuestionRadio
-                                id={'taxWithholdAnswer'}
-                                name={'paymentDetails.taxWithhold.answer'}
-                                legend={t('doYouWantUsToWithholdTax')}
-                            />
-                        </FormElement>
-
-                        {withholdingTaxChildrensPension === JaNeiVetIkke.JA && (
-                            <>
-                                <FormElement>
-                                    <RHFRadio
-                                        name={'paymentDetails.taxWithhold.type'}
-                                        legend={t('taxPercentageType')}
-                                        children={Object.values(KronerEllerProsentType).map((value) => {
-                                            return { children: t(value), value } as RadioProps
-                                        })}
-                                    />
-                                </FormElement>
-                                <FormElement>
-                                    {withholdingTaxType && (
-                                        <RHFNumberInput
-                                            name={'paymentDetails.taxWithhold.taxPercentage'}
-                                            label={t(
-                                                withholdingTaxType === KronerEllerProsentType.KRONER
-                                                    ? 'desiredTaxKroner'
-                                                    : 'desiredTaxPercentage'
-                                            )}
-                                            htmlSize={Bredde.XS}
-                                        />
-                                    )}
-                                </FormElement>
-                                <FormElement>
-                                    <RHFInputArea
-                                        name={'paymentDetails.taxWithhold.description'}
-                                        label={t('taxPercentageDescription')}
-                                        maxLength={200}
-                                        valgfri
-                                    />
-                                </FormElement>
-                                <FormElement>
-                                    <Box padding="4" borderWidth="1" borderRadius="small">
-                                        <Alert variant={'info'} inline>
-                                            <BodyShort>{t('taxWithholdMustBeSentYearly')}</BodyShort>
-                                        </Alert>
-                                    </Box>
-                                </FormElement>
-                            </>
-                        )}
-                    </FormGroup>
                 </>
             )}
 

--- a/apps/barnepensjon-ui/src/locales/en.ts
+++ b/apps/barnepensjon-ui/src/locales/en.ts
@@ -387,9 +387,8 @@ const summary = {
         'We have already received an application for one or more of the children named in the application.\n\n' +
         'If you want to change any information on a submitted application, you must use the form ' +
         '<a href="https://www.nav.no/soknader/nb/person/diverse/div-dokumentasjon">Miscellaneous documentation</a>. ' +
-        'You also need to submit the appropriate form to change <a href="https://www.nav.no/start/soknad-endring-bankkontonummer/en">account number</a> ' +
-        'or <a href="https://www.nav.no/skattetrekk#trekke-mer-skatt">voluntary tax deduction</a>. ' +
-        'All of these must be sent by conventional mail.\n\n If you send any changes, you must contact us by phone ' +
+        'You also need to submit the appropriate form to change <a href="https://www.nav.no/start/soknad-endring-bankkontonummer/en">account number</a>. ' +
+        'This must be sent by conventional mail.\n\n If you send any changes, you must contact us by phone ' +
         '<a href="tel:+47 55 55 33 34">55 55 33 34</a>, so that we can postpone processing the application.',
     errorWhenSending:
         'An error occurred while submitting. Please wait a moment and try again. If the error persists, you can report it <a href="https://www.nav.no/person/kontakt-oss/en/tilbakemeldinger/feil-og-mangler">here.</a>',

--- a/apps/barnepensjon-ui/src/locales/en.ts
+++ b/apps/barnepensjon-ui/src/locales/en.ts
@@ -85,23 +85,6 @@ const paymentDetails = {
     swift: 'The bank’s SWIFT code or BIC',
     swiftHelpText:
         'BIC stands for Bank Identifier Code, and is a unique code that identifies the bank. The BIC, which in some countries is called the SWIFT code, is required when making payments to a number of countries.',
-    doYouWantUsToWithholdTax: "Do you want us to make a tax deduction for the children's pension?",
-    desiredTaxPercentage: 'Voluntary tax deduction in percentage per month',
-    desiredTaxKroner: 'Voluntary tax deduction in kroner per month',
-    taxWithholdTitle: 'Voluntary tax deduction',
-    taxWithholdDescription1:
-        "A children's pension is taxable, but we do not deduct tax from the amount unless we have agreed with you to do so. You can add a voluntary tax deduction as a percentage of your pension or as a fixed amount. This ensures that your tax payment is correct, and it minimises the risk of back taxes.",
-    taxWithholdDescription2: 'If you have questions about the amount of the tax deduction, you must ',
-    taxWithholdDescription2Href:
-        'https://www.skatteetaten.no/en/person/taxes/get-the-taxes-right/family-and-health/children/children-and-young-people-with-their-own-income-or-capital/',
-    taxWithholdDescription2HrefText: 'contact the Norwegian Tax Administration',
-    taxWithholdDescription3:
-        'You can pause the application process for up to 72 hours, but you must save this page by pressing "Next" before you take a break.',
-    taxPercentageType: 'Do you want to make a voluntary tax deduction in kroner or as a percentage?',
-    taxPercentageDescription:
-        'Please notify us if you do no want a deduction made in December or in other parts of year (optional)',
-    taxWithholdMustBeSentYearly:
-        'You retain the voluntary tax deduction in future years until you notify us about a change.',
 }
 
 const radiobuttons = {
@@ -445,10 +428,6 @@ const error = {
     'memberFolketrygdenAbroad.required':
         'State whether you are a member of the Norwegian National Insurance Scheme during your stay in a country other than Norway',
     'occupationalInjury.required': 'State whether the death was due to an occupational injury or occupational illness',
-    'paymentDetails.taxWithhold.answer.required': 'State whether you wish to add tax deductions ',
-    'paymentDetails.taxWithhold.type.required':
-        'State whether you wish to add tax deductions in kroner or as percentage',
-    'paymentDetails.taxWithhold.taxPercentage.required': 'Enter a valid voluntary tax deduction',
     'paymentDetails.bankAccount.required': 'Norwegian bank account number is a required field (11 digits)',
     'paymentDetails.bankAccount.pattern': 'Invalid account number It must have 11 digits',
     'paymentDetails.accountType.required':

--- a/apps/barnepensjon-ui/src/locales/nb.ts
+++ b/apps/barnepensjon-ui/src/locales/nb.ts
@@ -83,23 +83,6 @@ const paymentDetails = {
     swift: 'Bankens S.W.I.F.T (BIC) adresse',
     swiftHelpText:
         'BIC står for Bank Identifier Code, og er den koden som identifiserer banken. BIC kalles også SWIFT, og er påkrevd ved betaling til en rekke land.',
-    doYouWantUsToWithholdTax: 'Ønsker du at vi legger inn et skattetrekk for barnepensjonen?',
-    desiredTaxPercentage: 'Frivillig skattetrekk i prosent per måned',
-    desiredTaxKroner: 'Frivillig skattetrekk i kroner per måned',
-    taxWithholdTitle: 'Frivillig skattetrekk',
-    taxWithholdDescription1:
-        'Barnepensjon er skattepliktig, men vi trekker ikke skatt av beløpet uten at det er avtalt. Du kan legge til et frivillig skattetrekk som en prosentandel av pensjonen eller som et fast beløp. Dette sikrer at skatten blir riktig og gir mindre risiko for restskatt.',
-    taxWithholdDescription2: 'Har du spørsmål om størrelsen på skattetrekket må du ',
-    taxWithholdDescription2Href:
-        'https://www.skatteetaten.no/person/skatt/hjelp-til-riktig-skatt/familie-og-helse/barn/barn-og-ungdom-med-egen-inntekt-eller-formue/',
-    taxWithholdDescription2HrefText: 'ta kontakt med Skatteetaten',
-    taxWithholdDescription3:
-        'Du kan trygt ta pause fra søknaden i inntil 72 timer, men du må lagre denne siden ved å trykke på "Neste" før du tar pause.',
-    taxPercentageType: 'Ønsker du frivillig skattetrekk i kroner eller prosent?',
-    taxPercentageDescription:
-        'Vi trenger beskjed hvis det ikke skal være trekk i desember eller andre deler av året (valgfritt)',
-    taxWithholdMustBeSentYearly:
-        'Du beholder det frivillige skattetrekket i årene fremover til du selv melder fra om endring.',
 }
 
 const radiobuttons = {
@@ -436,9 +419,6 @@ const error = {
         'For å sende inn søknaden må du søke om barnepensjon for minst ett barn. Du kan endre utfyllingen ved å klikke på "endre" ved det barnet du ønsker å søke for.',
     'memberFolketrygdenAbroad.required': 'Oppgi om du er medlem i folketrygden under opphold i et annet land enn Norge',
     'occupationalInjury.required': 'Oppgi om dødsfallet skyldes yrkesskade eller yrkessykdom',
-    'paymentDetails.taxWithhold.answer.required': 'Oppgi om du ønsker skattetrekk for barnepensjonen',
-    'paymentDetails.taxWithhold.type.required': 'Oppgi frivillig skattetrekk i kroner eller i prosent',
-    'paymentDetails.taxWithhold.taxPercentage.required': 'Oppgi et gyldig skattetrekk',
     'paymentDetails.bankAccount.required': 'Norsk kontonummer må fylles ut (11 siffer)',
     'paymentDetails.bankAccount.pattern': 'Kontonummer ikke gyldig. Må bestå av 11 siffer',
     'paymentDetails.accountType.required': 'Du må velge mellom norsk eller utenlandsk bankkonto for utbetaling',

--- a/apps/barnepensjon-ui/src/locales/nb.ts
+++ b/apps/barnepensjon-ui/src/locales/nb.ts
@@ -379,10 +379,9 @@ const summary = {
         'Vi har allerede mottatt en søknad på et eller flere av barna det søkes for.\n\n' +
         'Dersom du ønsker å endre informasjon på en innsendt søknad må du benytte skjema ' +
         '<a href="https://www.nav.no/soknader/nb/person/diverse/div-dokumentasjon">Diverse dokumentasjon</a>. ' +
-        'Det kreves også egne skjema for endring av ' +
-        '<a href="https://www.nav.no/start/soknad-endring-bankkontonummer">kontonummer</a> eller ' +
-        '<a href="https://www.nav.no/skattetrekk#trekke-mer-skatt">frivillig skattetrekk</a>. ' +
-        'Felles for disse er at de må sendes inn pr post.\n\n' +
+        'Det kreves også eget skjema for endring av ' +
+        '<a href="https://www.nav.no/start/soknad-endring-bankkontonummer">kontonummer</a>. ' +
+        'Dette må sendes inn pr post.\n\n' +
         'Sender du inn endringer må du gi oss beskjed ved å kontakte oss på telefon <a href="tel:+47 55 55 33 34">55 55 33 34</a>, slik at vi venter med saksbehandlingen av søknaden.',
     errorWhenSending:
         'En feil oppsto ved sending. Vent litt og prøv på nytt. Dersom feilen vedvarer kan du melde feil <a href="https://www.nav.no/person/kontakt-oss/nb/tilbakemeldinger/feil-og-mangler">her.</a>',

--- a/apps/barnepensjon-ui/src/locales/nn.ts
+++ b/apps/barnepensjon-ui/src/locales/nn.ts
@@ -377,9 +377,8 @@ const summary = {
         'Vi har allereie fått ein søknad på eitt eller fleire av barna det blir søkt for.\n\n' +
         'Dersom du ønskjer å endre informasjon på ein innsend søknad, nyttar du skjemaet ' +
         '<a href="https://www.nav.no/soknader/nb/person/diverse/div-dokumentasjon">Diverse dokumentasjon</a>. ' +
-        'Eige skjema må også fyllast ut ved endring av <a href="https://www.nav.no/start/soknad-endring-bankkontonummer/nn">kontonummer</a> ' +
-        'eller <a href="https://www.nav.no/skattetrekk#trekke-mer-skatt">frivillig skattetrekk</a>. ' +
-        'Felles for desse er at dei må sendast inn per post.\n\n Viss du sender inn endringar, må du gi oss beskjed ' +
+        'Eige skjema må også fyllast ut ved endring av <a href="https://www.nav.no/start/soknad-endring-bankkontonummer/nn">kontonummer</a>. ' +
+        'Dette må sendast inn per post.\n\n Viss du sender inn endringar, må du gi oss beskjed ' +
         'ved å ringje oss på telefon <a href="tel:+47 55 55 33 34">55 55 33 34</a>, slik at vi ventar med å behandle søknaden.',
     errorWhenSending:
         'Ein feil oppstod ved sending. Vent litt og prøv på nytt. Dersom feilen varer kan du melde feil <a href="https://www.nav.no/person/kontakt-oss/nn/tilbakemeldinger/feil-og-mangler">her.</a>',

--- a/apps/barnepensjon-ui/src/locales/nn.ts
+++ b/apps/barnepensjon-ui/src/locales/nn.ts
@@ -83,23 +83,6 @@ const paymentDetails = {
     swift: 'Bankens S.W.I.F.T (BIC) adresse',
     swiftHelpText:
         'BIC står for Bank Identifier Code, og er den koden som identifiserer banken. BIC kallast også SWIFT, og er påkrevd ved betaling til ei rekke land.',
-    doYouWantUsToWithholdTax: 'Vil du at vi skal leggje inn skattetrekk for barnepensjonen?',
-    desiredTaxPercentage: 'Frivillig skattetrekk i prosent per månad',
-    desiredTaxKroner: 'Frivillig skattetrekk i kroner per månad',
-    taxWithholdTitle: 'Frivillig skattetrekk',
-    taxWithholdDescription1:
-        'Barnepensjon er skattepliktig, men vi trekkjer ikkje skatt av beløpet utan at det er avtalt. Du kan leggje til eit frivillig skattetrekk anten som prosentdel av pensjonen eller som fast beløp. Dette sikrar at skatten blir rett, og gir mindre risiko for restskatt.',
-    taxWithholdDescription2: ' ',
-    taxWithholdDescription2Href:
-        'https://www.skatteetaten.no/nn/person/skatt/hjelp-til-rett-skatt/familie-og-helse/barn/barn-og-ungdom-med-eiga-inntekt-eller-formue/',
-    taxWithholdDescription2HrefText: 'Kontakt Skatteetaten dersom du har spørsmål om kor stort skattetrekket vil vere',
-    taxWithholdDescription3:
-        'Du kan trygt ta pause frå søknaden i opptil 72 timar, men du må då hugse å lagre denne sida ved å trykkje på «Neste» før du tek pause.',
-    taxPercentageType: 'Vil du ha frivillig skattetrekk i kroner eller i prosent?',
-    taxPercentageDescription:
-        'Vi må få beskjed dersom det ikkje skal vere trekk i desember eller andre delar av året (valfritt)',
-    taxWithholdMustBeSentYearly:
-        'Du beheld det frivillige skattetrekket i åra vidare fram til du sjølv melder frå om endring.',
 }
 
 const radiobuttons = {
@@ -433,9 +416,6 @@ const error = {
         'For å sende inn søknaden må du søkje om barnepensjon for minst eitt barn. Du kan endre utfyllinga ved å klikke på «endre» ved sida av barnet du ønskjer å søkje for.',
     'memberFolketrygdenAbroad.required': 'Oppgi om du er medlem i folketrygda under opphald i eit anna land enn Noreg',
     'occupationalInjury.required': 'Oppgi om dødsfallet skuldast yrkesskade eller yrkessjukdom',
-    'paymentDetails.taxWithhold.answer.required': 'Oppgi om du vil at vi skal leggje til skattetrekk',
-    'paymentDetails.taxWithhold.type.required': 'Oppgi om du vil ha frivillig skattetrekk i kroner eller i prosent',
-    'paymentDetails.taxWithhold.taxPercentage.required': 'Oppgi eit gyldig skattetrekk',
     'paymentDetails.bankAccount.required': 'Norsk kontonummer må fyllast ut (11 siffer)',
     'paymentDetails.bankAccount.pattern': 'Kontonummer ikkje gyldig. Må bestå av 11 siffer',
     'paymentDetails.accountType.required': 'Du må velja mellom norsk eller utanlandsk bankkonto for utbetaling',

--- a/apps/barnepensjon-ui/src/types/person.ts
+++ b/apps/barnepensjon-ui/src/types/person.ts
@@ -1,4 +1,4 @@
-import { BankkontoType, JaNeiVetIkke, KronerEllerProsentType } from '../api/dto/FellesOpplysninger'
+import { BankkontoType, JaNeiVetIkke } from '../api/dto/FellesOpplysninger'
 
 export interface IAboutYou {
     addressOfResidenceConfirmed?: JaNeiVetIkke
@@ -23,12 +23,6 @@ export interface IPaymentDetails {
     foreignBankAddress?: string
     iban?: string
     swift?: string
-    taxWithhold?: {
-        answer?: JaNeiVetIkke
-        type?: KronerEllerProsentType
-        taxPercentage?: string
-        description?: string
-    }
 }
 
 export interface IAboutChildren {

--- a/apps/omstillingsstoenad-ui/cypress/e2e/enkel_soeknadsflyt.cy.js
+++ b/apps/omstillingsstoenad-ui/cypress/e2e/enkel_soeknadsflyt.cy.js
@@ -319,7 +319,6 @@ describe('Skal gå igjennom hele søknaden uten feil', () => {
                 // under 18 år
                 selectValueForId('harBarnetVerge.svar', barn.harBarnetVerge.svar)
                 selectValueForId('barnepensjon.kontonummer.svar', barn.barnepensjon.kontonummer.svar)
-                selectValueForId('barnepensjon.forskuddstrekk.svar', barn.barnepensjon.forskuddstrekk.svar)
             }
             getById('leggTilBarn').click()
         })

--- a/apps/omstillingsstoenad-ui/src/api/dto/FellesOpplysninger.ts
+++ b/apps/omstillingsstoenad-ui/src/api/dto/FellesOpplysninger.ts
@@ -43,13 +43,6 @@ export interface UtbetalingsInformasjon {
     utenlandskBankAdresse?: Opplysning<FritekstSvar>
     iban?: Opplysning<FritekstSvar>
     swift?: Opplysning<FritekstSvar>
-    skattetrekk?: SkatteTrekk
-}
-
-export interface SkatteTrekk {
-    svar: Opplysning<EnumSvar<JaNeiVetIkke>>
-    trekk?: Opplysning<FritekstSvar>
-    beskrivelse?: Opplysning<FritekstSvar>
 }
 
 export interface Kontaktinfo {

--- a/apps/omstillingsstoenad-ui/src/api/mapper/fellesMapper.ts
+++ b/apps/omstillingsstoenad-ui/src/api/mapper/fellesMapper.ts
@@ -6,7 +6,6 @@ import {
     EnumSvar,
     JaNeiVetIkke,
     Opplysning,
-    SkatteTrekk,
     UtbetalingsInformasjon,
     Utenlandsadresse,
 } from '../dto/FellesOpplysninger'
@@ -21,11 +20,7 @@ import {
     PersonType,
     Verge,
 } from '../dto/Person'
-import {
-    BankkontoType as GammelBankkontoType,
-    IUtbetalingsInformasjon,
-    KronerEllerProsentType,
-} from '../../typer/utbetaling'
+import { BankkontoType as GammelBankkontoType, IUtbetalingsInformasjon } from '../../typer/utbetaling'
 import { IValg } from '../../typer/Spoersmaal'
 import { ISoeknad } from '../../context/soknad/soknad'
 import { IBruker } from '../../context/bruker/bruker'
@@ -233,7 +228,6 @@ export const hentUtbetalingsInformasjonBarn = (
             ...gjenlevendeSinKonto,
             opplysning: {
                 ...gjenlevendeSinKonto?.opplysning,
-                skattetrekk: hentSkattetrekk(t, soeker),
             },
         }
     } else if (soeker.barnepensjon?.kontonummer?.svar === IValg.NEI) {
@@ -245,51 +239,10 @@ export const hentUtbetalingsInformasjonBarn = (
             ...barnetSinKonto,
             opplysning: {
                 ...barnetSinKonto?.opplysning,
-                skattetrekk: hentSkattetrekk(t, soeker),
             },
         }
     }
 
-    return undefined
-}
-
-const hentSkattetrekk = (t: TFunction, soeker: IBarn): SkatteTrekk | undefined => {
-    if (soeker.barnepensjon?.forskuddstrekk?.svar === IValg.JA) {
-        return {
-            svar: {
-                spoersmaal: t('omBarn.barnepensjon.forskuddstrekk.svar'),
-                svar: valgTilSvar(t, soeker.barnepensjon!.forskuddstrekk!.svar!),
-            },
-            trekk:
-                soeker.barnepensjon!.forskuddstrekk!.type! === KronerEllerProsentType.kroner
-                    ? {
-                          spoersmaal: t('omBarn.barnepensjon.forskuddstrekk.trekk.kroner'),
-                          svar: {
-                              innhold:
-                                  soeker.barnepensjon!.forskuddstrekk!.trekkprosent! +
-                                  ' ' +
-                                  t(soeker.barnepensjon!.forskuddstrekk!.type!),
-                          },
-                      }
-                    : {
-                          spoersmaal: t('omBarn.barnepensjon.forskuddstrekk.trekk.prosent'),
-                          svar: {
-                              innhold:
-                                  soeker.barnepensjon!.forskuddstrekk!.trekkprosent! +
-                                  ' ' +
-                                  t(soeker.barnepensjon!.forskuddstrekk!.type!),
-                          },
-                      },
-            beskrivelse: soeker.barnepensjon!.forskuddstrekk!.beskrivelse
-                ? {
-                      spoersmaal: t('omBarn.barnepensjon.forskuddstrekk.beskrivelse'),
-                      svar: {
-                          innhold: soeker.barnepensjon!.forskuddstrekk!.beskrivelse!,
-                      },
-                  }
-                : undefined,
-        }
-    }
     return undefined
 }
 

--- a/apps/omstillingsstoenad-ui/src/assets/dummy-soeknad.json
+++ b/apps/omstillingsstoenad-ui/src/assets/dummy-soeknad.json
@@ -241,10 +241,6 @@
           "soeker": true,
           "kontonummer": {
             "svar": "radiobuttons.ja"
-          },
-          "forskuddstrekk": {
-            "svar": "radiobuttons.nei",
-            "trekkprosent": "21%"
           }
         }
       }

--- a/apps/omstillingsstoenad-ui/src/components/soknad/7-barnepensjon/LeggTilBarnSkjema.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/soknad/7-barnepensjon/LeggTilBarnSkjema.tsx
@@ -3,31 +3,13 @@ import { FormProvider, useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { BarnRelasjon, IBarn } from '../../../typer/person'
 import { RHFRadio, RHFSpoersmaalRadio } from '../../felles/rhf/RHFRadio'
-import {
-    RHFFoedselsnummerInput,
-    RHFInput,
-    RHFInputArea,
-    RHFKontonummerInput,
-    RHFNumberInput,
-} from '../../felles/rhf/RHFInput'
+import { RHFFoedselsnummerInput, RHFInput, RHFKontonummerInput } from '../../felles/rhf/RHFInput'
 import { IValg } from '../../../typer/Spoersmaal'
 import Feilmeldinger from '../../felles/Feilmeldinger'
 import { hentAlder, hentAlderFraFoedselsnummer } from '../../../utils/dato'
 import { erMyndig } from '../../../utils/alder'
 import { fnr } from '@navikt/fnrvalidator'
-import {
-    Alert,
-    BodyShort,
-    Box,
-    Button,
-    GuidePanel,
-    Heading,
-    HGrid,
-    Label,
-    Link,
-    RadioProps,
-    VStack,
-} from '@navikt/ds-react'
+import { Alert, BodyShort, Box, Button, GuidePanel, Heading, HGrid, Label, RadioProps, VStack } from '@navikt/ds-react'
 import { RHFCheckboks, RHFConfirmationPanel } from '../../felles/rhf/RHFCheckboksPanelGruppe'
 import useCountries, { Options } from '../../../hooks/useCountries'
 import ikon from '../../../assets/ikoner/barn1.svg'
@@ -39,8 +21,7 @@ import { SkjemaElement } from '../../felles/SkjemaElement'
 import Bredde from '../../../typer/bredde'
 import { isDev } from '../../../api/axios'
 import { Panel } from '../../felles/Panel'
-import { useSoknadContext } from '../../../context/soknad/SoknadContext'
-import { BankkontoType, KronerEllerProsentType } from '../../../typer/utbetaling'
+import { BankkontoType } from '~typer/utbetaling'
 import UtenlandskBankInfo from '../1-omdeg/utenlandskBankInfo/UtenlandskBankInfo'
 import Datovelger from '~components/felles/Datovelger'
 import { RHFCombobox } from '~components/felles/rhf/RHFCombobox'
@@ -108,7 +89,6 @@ const LeggTilBarnSkjema = ({ avbryt, lagre, barn, fnrRegistrerteBarn }: Props) =
     const { t } = useTranslation()
     const { countries }: { countries: Options[] } = useCountries()
     const { state: bruker } = useBrukerContext()
-    const { state: soeknad } = useSoknadContext()
     const { logEvent } = useAmplitude()
 
     const endrerBarn = !!barn?.fornavn?.length
@@ -156,8 +136,6 @@ const LeggTilBarnSkjema = ({ avbryt, lagre, barn, fnrRegistrerteBarn }: Props) =
     const foedselsdato: any = watch('foedselsdato')
     const ukjentFoedselsnummer: any = watch('ukjentFoedselsnummer')
     const annetKontonummerBarnepensjon = watch('barnepensjon.kontonummer.svar')
-    const forskuddstrekkBarnepensjon = watch('barnepensjon.forskuddstrekk.svar')
-    const forskuddstrekkType = watch('barnepensjon.forskuddstrekk.type')
     const bankkontoType = watch('barnepensjon.utbetalingsInformasjon.bankkontoType')
 
     const kanSoekeOmBarnepensjon = (): boolean => {
@@ -181,12 +159,6 @@ const LeggTilBarnSkjema = ({ avbryt, lagre, barn, fnrRegistrerteBarn }: Props) =
     useEffect(() => {
         window.scrollTo(0, 0)
     }, [])
-
-    const bankkontoErNorsk = (): boolean => {
-        if (annetKontonummerBarnepensjon === IValg.JA)
-            return soeknad.omDeg.utbetalingsInformasjon?.bankkontoType === BankkontoType.norsk
-        return bankkontoType === BankkontoType.norsk
-    }
 
     return (
         <>
@@ -379,96 +351,6 @@ const LeggTilBarnSkjema = ({ avbryt, lagre, barn, fnrRegistrerteBarn }: Props) =
                                                         )}
                                                     </SkjemaGruppe>
                                                 </SkjemaElement>
-                                            )}
-
-                                            {bankkontoErNorsk() && (
-                                                <SkjemaGruppe>
-                                                    <Label>{t('omBarn.barnepensjon.forskuddstrekk.tittel')}</Label>
-                                                    <BodyShort spacing>
-                                                        {t('omBarn.barnepensjon.forskuddstrekk.hjelpetekst.del1')}
-                                                    </BodyShort>
-                                                    <BodyShort spacing>
-                                                        {t('omBarn.barnepensjon.forskuddstrekk.hjelpetekst.del2')}
-                                                        <Link
-                                                            href={t(
-                                                                'omBarn.barnepensjon.forskuddstrekk.hjelpetekst.lenke.href'
-                                                            )}
-                                                            inlineText
-                                                        >
-                                                            {t(
-                                                                'omBarn.barnepensjon.forskuddstrekk.hjelpetekst.lenke.tekst'
-                                                            )}
-                                                        </Link>
-                                                        .
-                                                    </BodyShort>
-                                                    <BodyShort>
-                                                        {t('omBarn.barnepensjon.forskuddstrekk.hjelpetekst.del3')}
-                                                    </BodyShort>
-                                                    <br />
-                                                    <RHFSpoersmaalRadio
-                                                        name={'barnepensjon.forskuddstrekk.svar'}
-                                                        legend={t('omBarn.barnepensjon.forskuddstrekk.svar')}
-                                                    />
-
-                                                    {forskuddstrekkBarnepensjon === IValg.JA && (
-                                                        <>
-                                                            <SkjemaElement>
-                                                                <RHFRadio
-                                                                    name={'barnepensjon.forskuddstrekk.type'}
-                                                                    legend={t(
-                                                                        'omBarn.barnepensjon.forskuddstrekk.type'
-                                                                    )}
-                                                                >
-                                                                    {Object.values(KronerEllerProsentType).map(
-                                                                        (value) => {
-                                                                            return {
-                                                                                children: t(value),
-                                                                                value,
-                                                                            } as RadioProps
-                                                                        }
-                                                                    )}
-                                                                </RHFRadio>
-                                                            </SkjemaElement>
-                                                            <SkjemaElement>
-                                                                {forskuddstrekkType && (
-                                                                    <RHFNumberInput
-                                                                        htmlSize={Bredde.S}
-                                                                        name={
-                                                                            'barnepensjon.forskuddstrekk.trekkprosent'
-                                                                        }
-                                                                        label={t(
-                                                                            forskuddstrekkType ===
-                                                                                KronerEllerProsentType.kroner
-                                                                                ? 'omBarn.barnepensjon.forskuddstrekk.trekk.kroner'
-                                                                                : 'omBarn.barnepensjon.forskuddstrekk.trekk.prosent'
-                                                                        )}
-                                                                    />
-                                                                )}
-                                                            </SkjemaElement>
-                                                            <SkjemaElement>
-                                                                <RHFInputArea
-                                                                    name={'barnepensjon.forskuddstrekk.beskrivelse'}
-                                                                    label={t(
-                                                                        'omBarn.barnepensjon.forskuddstrekk.beskrivelse'
-                                                                    )}
-                                                                    maxLength={200}
-                                                                    resize={'vertical'}
-                                                                    valgfri
-                                                                />
-                                                            </SkjemaElement>
-                                                            <Panel border>
-                                                                <Alert
-                                                                    variant={'info'}
-                                                                    className={'navds-alert--inline'}
-                                                                >
-                                                                    <BodyShort>
-                                                                        {t('omBarn.barnepensjon.forskuddstrekk.info')}
-                                                                    </BodyShort>
-                                                                </Alert>
-                                                            </Panel>
-                                                        </>
-                                                    )}
-                                                </SkjemaGruppe>
                                             )}
                                         </>
                                     )}

--- a/apps/omstillingsstoenad-ui/src/components/soknad/8-oppsummering/fragmenter/OppsummeringBarnepensjon.tsx
+++ b/apps/omstillingsstoenad-ui/src/components/soknad/8-oppsummering/fragmenter/OppsummeringBarnepensjon.tsx
@@ -10,7 +10,6 @@ import { IValg } from '../../../../typer/Spoersmaal'
 import { SkjemaElement } from '../../../felles/SkjemaElement'
 import { Panel } from '../../../felles/Panel'
 import UtbetalingsInformasjonOppsummering from './UtbetalingsInformasjonOppsummering'
-import { KronerEllerProsentType } from '../../../../typer/utbetaling'
 
 interface Props {
     opplysningerOmBarn: IOmBarn
@@ -105,36 +104,6 @@ export const OppsummeringBarnepensjon = memo(({ opplysningerOmBarn, senderSoekna
                                 <UtbetalingsInformasjonOppsummering
                                     utbetalingsInformasjon={barnet.barnepensjon.utbetalingsInformasjon!}
                                 />
-                            </Panel>
-                        )}
-
-                        {barnet.barnepensjon?.forskuddstrekk?.svar && (
-                            <TekstGruppeJaNeiVetIkke
-                                tittel={t('omBarn.barnepensjon.forskuddstrekk.svar')}
-                                innhold={barnet.barnepensjon?.forskuddstrekk?.svar}
-                            />
-                        )}
-
-                        {barnet.barnepensjon?.forskuddstrekk?.svar === IValg.JA && (
-                            <Panel>
-                                <TekstGruppe
-                                    tittel={t(
-                                        barnet.barnepensjon.forskuddstrekk.type === KronerEllerProsentType.kroner
-                                            ? 'omBarn.barnepensjon.forskuddstrekk.trekk.kroner'
-                                            : 'omBarn.barnepensjon.forskuddstrekk.trekk.prosent'
-                                    )}
-                                    innhold={
-                                        barnet.barnepensjon.forskuddstrekk.trekkprosent +
-                                        ' ' +
-                                        t(barnet.barnepensjon.forskuddstrekk.type!)
-                                    }
-                                />
-                                {barnet.barnepensjon?.forskuddstrekk.beskrivelse && (
-                                    <TekstGruppe
-                                        tittel={t('omBarn.barnepensjon.forskuddstrekk.beskrivelse')}
-                                        innhold={barnet.barnepensjon.forskuddstrekk.beskrivelse}
-                                    />
-                                )}
                             </Panel>
                         )}
 

--- a/apps/omstillingsstoenad-ui/src/locales/en.ts
+++ b/apps/omstillingsstoenad-ui/src/locales/en.ts
@@ -655,25 +655,6 @@ export default {
     'omBarn.barnepensjon.kontonummer.kontonummer':
         'Enter the Norwegian bank account number for payment of children’s pension',
     'omBarn.barnepensjon.kontonummer.placeholder': '11 digits',
-    'omBarn.barnepensjon.forskuddstrekk.tittel': 'Voluntary tax deduction',
-    'omBarn.barnepensjon.forskuddstrekk.hjelpetekst.del1':
-        "A children's pension is taxable, but we do not deduct tax from the amount unless we have agreed with you to do so. You can add a voluntary tax deduction as a percentage of your pension or as a fixed amount. This ensures that your tax payment is correct, and it minimises the risk of back taxes.",
-    'omBarn.barnepensjon.forskuddstrekk.hjelpetekst.del2':
-        'If you have questions about the amount of the tax deduction, you must ',
-    'omBarn.barnepensjon.forskuddstrekk.hjelpetekst.lenke.href':
-        'https://www.skatteetaten.no/en/person/taxes/get-the-taxes-right/family-and-health/children/children-and-young-people-with-their-own-income-or-capital/',
-    'omBarn.barnepensjon.forskuddstrekk.hjelpetekst.lenke.tekst': 'contact the Norwegian Tax Administration',
-    'omBarn.barnepensjon.forskuddstrekk.hjelpetekst.del3':
-        'You can pause the application process for up to 72 hours, but you must save this page by pressing "Next" before you take a break.',
-    'omBarn.barnepensjon.forskuddstrekk.svar': "Do you want us to make a tax deduction for the children's pension?",
-    'omBarn.barnepensjon.forskuddstrekk.type':
-        'Do you want to make a voluntary tax deduction in kroner or as a percentage?',
-    'omBarn.barnepensjon.forskuddstrekk.trekk.kroner': 'Voluntary tax deduction in kroner per month',
-    'omBarn.barnepensjon.forskuddstrekk.trekk.prosent': 'Voluntary tax deduction in percentage per month',
-    'omBarn.barnepensjon.forskuddstrekk.beskrivelse':
-        'Please notify us if you do no want a deduction made in December or in other parts of year (optional)',
-    'omBarn.barnepensjon.forskuddstrekk.info':
-        'You retain the voluntary tax deduction in future years until you notify us about a change.',
     'omBarn.infokort.foedselsnummer': 'NORWEGIAN NATIONAL IDENTITY NUMBER',
     'omBarn.infokort.foedselsdato': 'DATE OF BIRTH',
     'omBarn.infokort.foreldre': 'THE CHILD’S PARENTS',
@@ -1174,11 +1155,6 @@ export default {
     'feil.barnepensjon.utbetalingsInformasjon.iban.validate': 'Invalid IBAN',
     'feil.barnepensjon.utbetalingsInformasjon.swift.required': 'The bank’s SWIFT code or BIC is a required field',
     'feil.barnepensjon.utbetalingsInformasjon.swift.validate': 'Invalid SWIFT code or BIC',
-    'feil.barnepensjon.forskuddstrekk.svar.required':
-        'State whether you want tax to be deducted from the children’s pension',
-    'feil.barnepensjon.forskuddstrekk.type.required':
-        'State whether you want tax to be deducted in kroner or as a percentage',
-    'feil.barnepensjon.forskuddstrekk.trekkprosent.required': 'Enter a valid voluntary tax deduction',
     'feil.dagligOmsorg.required': 'State whether you have the daily care for the child',
     'feil.harBarnetVerge.svar.required': 'State whether a guardian has been appointed for the child',
     'feil.harBarnetVerge.fornavn.pattern': 'Invalid first name',

--- a/apps/omstillingsstoenad-ui/src/locales/nb.ts
+++ b/apps/omstillingsstoenad-ui/src/locales/nb.ts
@@ -628,23 +628,6 @@ export default {
     'omBarn.barnepensjon.kontonummer.informasjon': 'Du kan legge til et eget kontonummer for barnet.',
     'omBarn.barnepensjon.kontonummer.kontonummer': 'Oppgi norsk kontonummer for utbetaling av barnepensjon',
     'omBarn.barnepensjon.kontonummer.placeholder': '11 siffer',
-    'omBarn.barnepensjon.forskuddstrekk.tittel': 'Frivillig skattetrekk',
-    'omBarn.barnepensjon.forskuddstrekk.hjelpetekst.del1':
-        'Barnepensjon er skattepliktig, men vi trekker ikke skatt av beløpet uten at det er avtalt. Du kan legge til et frivillig skattetrekk som en prosentandel av pensjonen eller som et fast beløp. Dette sikrer at skatten blir riktig og gir mindre risiko for restskatt. \n',
-    'omBarn.barnepensjon.forskuddstrekk.hjelpetekst.del2': 'Har du spørsmål om størrelsen på skattetrekket må ',
-    'omBarn.barnepensjon.forskuddstrekk.hjelpetekst.lenke.href':
-        'https://www.skatteetaten.no/person/skatt/hjelp-til-riktig-skatt/familie-og-helse/barn/barn-og-ungdom-med-egen-inntekt-eller-formue/',
-    'omBarn.barnepensjon.forskuddstrekk.hjelpetekst.lenke.tekst': 'du ta kontakt med Skatteetaten',
-    'omBarn.barnepensjon.forskuddstrekk.hjelpetekst.del3':
-        'Du kan trygt ta pause fra søknaden i inntil 72 timer, men du må lagre denne siden ved å trykke på "Neste" før du tar pause. ',
-    'omBarn.barnepensjon.forskuddstrekk.svar': 'Ønsker du at vi legger inn et skattetrekk for barnepensjonen?',
-    'omBarn.barnepensjon.forskuddstrekk.type': 'Ønsker du frivillig skattetrekk i kroner eller prosent?',
-    'omBarn.barnepensjon.forskuddstrekk.trekk.kroner': 'Frivillig skattetrekk i kroner per måned',
-    'omBarn.barnepensjon.forskuddstrekk.trekk.prosent': 'Frivillig skattetrekk i prosent per måned',
-    'omBarn.barnepensjon.forskuddstrekk.beskrivelse':
-        'Vi trenger beskjed hvis det ikke skal være trekk i desember eller andre deler av året (valgfritt)',
-    'omBarn.barnepensjon.forskuddstrekk.info':
-        'Du beholder det frivillige skattetrekket i årene fremover til du selv melder fra om endring.',
     'omBarn.infokort.foedselsnummer': 'FØDSELSNUMMER',
     'omBarn.infokort.foedselsdato': 'FØDSELSDATO',
     'omBarn.infokort.foreldre': 'FORELDRE TIL BARNET',
@@ -1123,9 +1106,6 @@ export default {
     'feil.barnepensjon.utbetalingsInformasjon.iban.validate': 'Ugyldig IBAN-nummer',
     'feil.barnepensjon.utbetalingsInformasjon.swift.required': 'Bankens S.W.I.F.T (BIC) adresse må fylles ut',
     'feil.barnepensjon.utbetalingsInformasjon.swift.validate': 'Ugyldig SWIFT/BIC kode',
-    'feil.barnepensjon.forskuddstrekk.svar.required': 'Oppgi om du ønsker skattetrekk for barnepensjonen',
-    'feil.barnepensjon.forskuddstrekk.type.required': 'Oppgi frivillig skattetrekk i kroner eller i prosent',
-    'feil.barnepensjon.forskuddstrekk.trekkprosent.required': 'Oppgi et gyldig skattetrekk',
     'feil.dagligOmsorg.required': 'Oppgi om du har daglig omsorg for barnet',
     'feil.harBarnetVerge.svar.required': 'Oppgi om det er oppnevnt en verge for barnet',
     'feil.harBarnetVerge.fornavn.pattern': 'Ugyldig fornavn',

--- a/apps/omstillingsstoenad-ui/src/locales/nn.ts
+++ b/apps/omstillingsstoenad-ui/src/locales/nn.ts
@@ -624,24 +624,6 @@ export default {
     'omBarn.barnepensjon.kontonummer.informasjon': 'Du kan legge til eige kontonummer for barnet',
     'omBarn.barnepensjon.kontonummer.kontonummer': 'Oppgi norsk kontonummer for utbetaling av barnepensjon',
     'omBarn.barnepensjon.kontonummer.placeholder': '11 siffer',
-    'omBarn.barnepensjon.forskuddstrekk.tittel': 'Frivillig skattetrekk',
-    'omBarn.barnepensjon.forskuddstrekk.hjelpetekst.del1':
-        'Barnepensjon er skattepliktig, men vi trekkjer ikkje skatt av beløpet utan at det er avtalt. Du kan leggje til eit frivillig skattetrekk anten som prosentdel av pensjonen eller som fast beløp. Dette sikrar at skatten blir rett, og gir mindre risiko for restskatt.',
-    'omBarn.barnepensjon.forskuddstrekk.hjelpetekst.del2': ' ',
-    'omBarn.barnepensjon.forskuddstrekk.hjelpetekst.lenke.href':
-        'https://www.skatteetaten.no/nn/person/skatt/hjelp-til-rett-skatt/familie-og-helse/barn/barn-og-ungdom-med-eiga-inntekt-eller-formue/',
-    'omBarn.barnepensjon.forskuddstrekk.hjelpetekst.lenke.tekst':
-        'Kontakt Skatteetaten dersom du har spørsmål om kor stort skattetrekket vil vere',
-    'omBarn.barnepensjon.forskuddstrekk.hjelpetekst.del3':
-        'Du kan trygt ta pause frå søknaden i opptil 72 timar, men du må då hugse å lagre denne sida ved åtrykkje på «Neste» før du tek pause.',
-    'omBarn.barnepensjon.forskuddstrekk.svar': 'Vil du at vi skal leggje inn skattetrekk for barnepensjonen?',
-    'omBarn.barnepensjon.forskuddstrekk.type': 'Vil du ha frivillig skattetrekk i kroner eller i prosent?',
-    'omBarn.barnepensjon.forskuddstrekk.trekk.kroner': 'Frivillig skattetrekk i kroner per månad',
-    'omBarn.barnepensjon.forskuddstrekk.trekk.prosent': 'Frivillig skattetrekk i prosent per måned',
-    'omBarn.barnepensjon.forskuddstrekk.beskrivelse':
-        'Vi må få beskjed dersom det ikkje skal vere trekk i desember eller andre delar av året (valfritt)',
-    'omBarn.barnepensjon.forskuddstrekk.info':
-        'Du beheld det frivillige skattetrekket i åra vidare fram til du sjølv melder frå om endring.',
     'omBarn.infokort.foedselsnummer': 'FØDSELSNUMMER',
     'omBarn.infokort.foedselsdato': 'FØDSELSDATO',
     'omBarn.infokort.foreldre': 'FORELDRE TIL BARNET',
@@ -1126,10 +1108,6 @@ export default {
     'feil.barnepensjon.utbetalingsInformasjon.iban.validate': 'Ugyldig IBAN-nummer',
     'feil.barnepensjon.utbetalingsInformasjon.swift.required': 'Bankens S.W.I.F.T (BIC) adresse må fyllast ut',
     'feil.barnepensjon.utbetalingsInformasjon.swift.validate': 'Ugyldig SWIFT/BIC kode',
-    'feil.barnepensjon.forskuddstrekk.svar.required': 'Oppgi om du vil at vi skal leggje til skattetrekk',
-    'feil.barnepensjon.forskuddstrekk.type.required':
-        'Oppgi om du vil ha frivillig skattetrekk i kroner eller i prosent',
-    'feil.barnepensjon.forskuddstrekk.trekkprosent.required': 'Oppgi eit gyldig skattetrekk',
     'feil.dagligOmsorg.required': 'Oppgi om du har dagleg omsorg for barnet',
     'feil.harBarnetVerge.svar.required': 'Oppgi om det er oppnemnt ei verje for barnet',
     'feil.harBarnetVerge.fornavn.pattern': 'Ugyldig førenamn',

--- a/apps/omstillingsstoenad-ui/src/typer/person.ts
+++ b/apps/omstillingsstoenad-ui/src/typer/person.ts
@@ -1,5 +1,5 @@
 import { IValg } from './Spoersmaal'
-import { IUtbetalingsInformasjon, KronerEllerProsentType } from './utbetaling'
+import { IUtbetalingsInformasjon } from './utbetaling'
 
 export enum Sivilstatus {
     enke = 'nySivilstatus.enke',
@@ -74,12 +74,6 @@ export interface IBarn {
             svar?: IValg
         }
         utbetalingsInformasjon?: IUtbetalingsInformasjon
-        forskuddstrekk?: {
-            svar?: IValg
-            type?: KronerEllerProsentType
-            trekkprosent?: string
-            beskrivelse?: string
-        }
     }
 }
 

--- a/apps/omstillingsstoenad-ui/src/typer/utbetaling.ts
+++ b/apps/omstillingsstoenad-ui/src/typer/utbetaling.ts
@@ -11,8 +11,3 @@ export enum BankkontoType {
     norsk = 'bankkontoType.norsk',
     utenlandsk = 'bankkontoType.utenlandsk',
 }
-
-export enum KronerEllerProsentType {
-    kroner = 'felles.kroner',
-    prosent = 'felles.prosent',
-}

--- a/apps/selvbetjening-backend/src/main/kotlin/inntektsjustering/InntektsjusteringRepository.kt
+++ b/apps/selvbetjening-backend/src/main/kotlin/inntektsjustering/InntektsjusteringRepository.kt
@@ -117,7 +117,6 @@ fun ResultSet.toInntektsjustering() =
     Inntektsjustering(
         id = UUID.fromString(getString("id")),
         fnr = getString("fnr"),
-        mottattDato = getTimestamp("innsendt").toLocalDateTime(),
         inntektsaar = getInt("inntektsaar"),
         arbeidsinntekt = getInt("arbeidsinntekt"),
         naeringsinntekt = getInt("naeringsinntekt"),

--- a/apps/selvbetjening-backend/src/test/kotlin/jobs/PubliserInntektsjusteringJobbTest.kt
+++ b/apps/selvbetjening-backend/src/test/kotlin/jobs/PubliserInntektsjusteringJobbTest.kt
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import java.time.Instant
-import java.time.LocalDateTime
 import java.util.UUID
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -39,7 +38,6 @@ internal class PubliserInntektsjusteringJobbTest {
             Inntektsjustering(
                 id = UUID.randomUUID(),
                 fnr = "12345678901",
-                mottattDato = LocalDateTime.now(),
                 inntektsaar = 2024,
                 arbeidsinntekt = 100,
                 naeringsinntekt = 200,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ navfelles-rapids-and-rivers = { module = "com.github.navikt:rapids-and-rivers", 
 navfelles-token-client-core = { module = "no.nav.security:token-client-core", version.ref = "token-version" }
 navfelles-token-validation-ktor = { module = "no.nav.security:token-validation-ktor-v2", version.ref = "token-version" }
 
-etterlatte-common = { module = "pensjon-etterlatte-felles:common", version = "2024.12.05-08.17.6c635e0dd676" }
+etterlatte-common = { module = "pensjon-etterlatte-felles:common", version = "2024.12.17-14.07.c494a46f7e43" }
 
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor-version" }
 ktor-client-auth = { module = "io.ktor:ktor-client-auth", version.ref = "ktor-version" }

--- a/libs/utils/src/testFixtures/kotlin/etterlatte/SoeknadFixtures.kt
+++ b/libs/utils/src/testFixtures/kotlin/etterlatte/SoeknadFixtures.kt
@@ -139,7 +139,6 @@ object InnsendtSoeknadFixtures {
                             utenlandskBankAdresse = null,
                             iban = null,
                             swift = null,
-                            skattetrekk = null,
                         ),
                 ),
             soeker =


### PR DESCRIPTION
Første del av fjerning av frivillig skattetrekk. Splitter opp alle steg i egne PR for å unngå at det blir en gigantisk en. 

Denne omhandler da fjerning av frivillig skattetrekk fra søknaden til barnepensjon

Det som mangler

- [x] Fjerne fra søknad - OMS - https://github.com/navikt/pensjon-etterlatte/pull/1671
- [x] Fjerne fra backend - https://github.com/navikt/pensjon-etterlatte/pull/1672
- [x] Fjerne fra common - https://github.com/navikt/pensjon-etterlatte-felles/pull/373
- [x] Fjerne fra ey-pdfgen - https://github.com/navikt/pensjon-etterlatte-felles/pull/373
- [x] Oppdater apper med ny common - https://github.com/navikt/pensjon-etterlatte-saksbehandling/pull/6640