### PR TITLE
EY-4858: Oppdater knapper legg til barn

### DIFF
--- a/apps/barnepensjon-ui/src/components/application/about-children/ChildInfocard.tsx
+++ b/apps/barnepensjon-ui/src/components/application/about-children/ChildInfocard.tsx
@@ -1,18 +1,10 @@
 import { DeleteFilled, EditFilled } from '@navikt/ds-icons'
-import { BodyLong, BodyShort, Heading, Tag } from '@navikt/ds-react'
+import { BodyShort, Box, Button, Heading, Tag, VStack } from '@navikt/ds-react'
 import { memo } from 'react'
 import { JaNeiVetIkke } from '../../../api/dto/FellesOpplysninger'
 import ikon from '../../../assets/barn1.svg'
 import useTranslation from '../../../hooks/useTranslation'
-import {
-    Infocard,
-    InfocardFooter,
-    InfocardFooterLink,
-    InfocardHeader,
-    InformationBox,
-    InformationBoxContent,
-    InformationElement,
-} from '../../common/card/InfoCard'
+import { Infocard, InfocardHeader, InformationBox, InformationBoxContent } from '../../common/card/InfoCard'
 import { IChild } from '../../../types/person'
 import FormElement from '../../common/FormElement'
 import { format } from 'date-fns'
@@ -41,7 +33,7 @@ const ChildInfoCard = memo(({ child, index, remove, setActiveChildIndex }: Props
                         {child.firstName} {child.lastName}
                     </Heading>
                 </InformationBoxContent>
-                <InformationElement>
+                <Box paddingBlock="2">
                     {foedselsnummer && (
                         <>
                             <BodyShort>{t('infoCard_fnr')}</BodyShort>
@@ -75,29 +67,26 @@ const ChildInfoCard = memo(({ child, index, remove, setActiveChildIndex }: Props
                             <Tag variant={'warning'}>{t('childNotApplyingForPension')}</Tag>
                         </FormElement>
                     )}
-                </InformationElement>
-            </InformationBox>
-
-            <InfocardFooter>
-                <BodyLong>
-                    <InfocardFooterLink
-                        href={'#'}
-                        onClick={(e: any) => {
-                            e.preventDefault()
-                            setActiveChildIndex()
-                        }}
+                </Box>
+                <VStack gap="2">
+                    <Button
+                        type="button"
+                        icon={<EditFilled fontSize={18} />}
+                        onClick={setActiveChildIndex}
+                        variant="tertiary"
                     >
-                        <EditFilled />
-                        <span>{t('editButton', { ns: 'btn' })}</span>
-                    </InfocardFooterLink>
-                </BodyLong>
-                <BodyLong>
-                    <InfocardFooterLink href={'#'} onClick={() => remove(index)}>
-                        <DeleteFilled />
-                        <span>{t('removeChildButton')}</span>
-                    </InfocardFooterLink>
-                </BodyLong>
-            </InfocardFooter>
+                        {t('editButton', { ns: 'btn' })}
+                    </Button>
+                    <Button
+                        type="button"
+                        icon={<DeleteFilled fontSize={18} />}
+                        onClick={() => remove(index)}
+                        variant="tertiary"
+                    >
+                        {t('removeChildButton')}
+                    </Button>
+                </VStack>
+            </InformationBox>
         </Infocard>
     )
 })

--- a/apps/barnepensjon-ui/src/components/application/about-children/add-child/AddChildToForm.tsx
+++ b/apps/barnepensjon-ui/src/components/application/about-children/add-child/AddChildToForm.tsx
@@ -99,6 +99,8 @@ const AddChildToForm = ({ cancel, save, child, fnrRegisteredChild, isChild, isGu
         shouldUnregister: true,
     })
 
+    const editsChild = !!child?.firstName?.length
+
     const {
         formState: { errors },
         handleSubmit,
@@ -264,9 +266,7 @@ const AddChildToForm = ({ cancel, save, child, fnrRegisteredChild, isChild, isGu
                                 onClick={handleSubmit(addAndClose, logErrors)}
                                 style={{ minWidth: '80px' }}
                             >
-                                {child?.fnrDnr === undefined
-                                    ? t('addButton', { ns: 'btn' })
-                                    : t('saveButton', { ns: 'btn' })}
+                                {editsChild ? t('saveChangesButton', { ns: 'btn' }) : t('addButton', { ns: 'btn' })}
                             </Button>
                         </NavRow>
                     </ChangeChildPanelContent>

--- a/apps/barnepensjon-ui/src/components/application/about-parents/ParentInfoCard.tsx
+++ b/apps/barnepensjon-ui/src/components/application/about-parents/ParentInfoCard.tsx
@@ -1,9 +1,9 @@
 import { DeleteFilled, EditFilled } from '@navikt/ds-icons'
-import { BodyShort, Button, ErrorMessage, Heading, VStack } from '@navikt/ds-react'
+import { BodyShort, Box, Button, ErrorMessage, Heading, VStack } from '@navikt/ds-react'
 import { memo } from 'react'
 import ikon from '../../../assets/ukjent_person.svg'
 import useTranslation from '../../../hooks/useTranslation'
-import { Infocard, InfocardHeader, InformationBox, InformationElement } from '../../common/card/InfoCard'
+import { Infocard, InfocardHeader, InformationBox } from '../../common/card/InfoCard'
 import { IParent } from '~context/application/application'
 
 interface Props {
@@ -30,14 +30,14 @@ const ParentInfoCard = memo(({ parent, edit, remove, isValidated, firstParent }:
                 <Heading size={'small'} spacing>
                     {parent.firstName} {parent.lastName}
                 </Heading>
-                <InformationElement>
+                <Box paddingBlock="2">
                     {/* TODO: Endre fnr / dnr tekst dynamisk ? */}
                     <BodyShort>{t('fnrDnr')}</BodyShort>
                     <BodyShort spacing>{foedselsnummer ?? '-'}</BodyShort>
 
                     <BodyShort>{t('citizenship')}</BodyShort>
                     <BodyShort spacing>{parent.citizenship ?? '-'}</BodyShort>
-                </InformationElement>
+                </Box>
                 <VStack gap="4">
                     {!isValidated && <ErrorMessage>{t('missingInformation', { ns: 'aboutParents' })}</ErrorMessage>}
 

--- a/apps/barnepensjon-ui/src/components/common/card/InfoCard.tsx
+++ b/apps/barnepensjon-ui/src/components/common/card/InfoCard.tsx
@@ -1,5 +1,4 @@
 import styled from 'styled-components'
-import { Link } from '@navikt/ds-react'
 
 export const InfocardWrapper = styled.div`
     display: flex;
@@ -40,17 +39,6 @@ export const InfocardHeader = styled.div`
     opacity: 0.4;
 `
 
-export const InfocardFooter = styled.div`
-    margin-bottom: 1rem;
-`
-
-export const InfocardFooterLink = styled(Link)`
-    display: flex;
-    justify-content: center;
-    flex-grow: 1;
-    text-align: center;
-`
-
 export const InformationBox = styled.div`
     padding: 2rem 2rem;
     text-align: center;
@@ -58,8 +46,4 @@ export const InformationBox = styled.div`
 
 export const InformationBoxContent = styled.div`
     text-align: center;
-`
-
-export const InformationElement = styled.div`
-    margin: 10px 0 10px 0;
 `

--- a/apps/barnepensjon-ui/src/locales/en.ts
+++ b/apps/barnepensjon-ui/src/locales/en.ts
@@ -46,6 +46,7 @@ const btn = {
     backButton: 'Back',
     nextButton: 'Next',
     saveButton: 'Save',
+    saveChangesButton: 'Save changes',
     addButton: 'Add',
     cancelButton: 'Cancel',
     removeButton: 'Remove',

--- a/apps/barnepensjon-ui/src/locales/nb.ts
+++ b/apps/barnepensjon-ui/src/locales/nb.ts
@@ -45,6 +45,7 @@ const btn = {
     backButton: 'Tilbake',
     nextButton: 'Neste',
     saveButton: 'Lagre',
+    saveChangesButton: 'Lagre endring',
     addButton: 'Legg til',
     cancelButton: 'Avbryt',
     removeButton: 'Fjern',

--- a/apps/barnepensjon-ui/src/locales/nn.ts
+++ b/apps/barnepensjon-ui/src/locales/nn.ts
@@ -45,6 +45,7 @@ const btn = {
     backButton: 'Tilbake',
     nextButton: 'Neste',
     saveButton: 'Lagre',
+    saveChangesButton: 'Lagre endring',
     addButton: 'Legg til',
     cancelButton: 'Avbryt',
     removeButton: 'Fjern',


### PR DESCRIPTION
Endre og fjerne barn har nå større mellomrom og er faktiske knapper.
![Skjermbilde 2024-12-19 kl  08 39 45](https://github.com/user-attachments/assets/a4b32083-9b92-4013-b306-a470da2a2ff9)

Lagre endring hvis man endrer ting på et barn
![Skjermbilde 2024-12-19 kl  08 39 50](https://github.com/user-attachments/assets/014c4eef-ce2b-4f2a-be61-915de13cedd5)

Fortsatt legg til hvis man legger til nytt barn
![Skjermbilde 2024-12-19 kl  08 39 56](https://github.com/user-attachments/assets/4dfd2f2b-726a-4378-95c8-3a0efcebf459)
