### PR TITLE
Use github-package-registry-mirror.gc.nav.no

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,17 +73,6 @@ subgraph ekstern["NAV felles"]
 end
 ```
 
-# Kom i gang
-
-Noen avhengigheter i prosjektet ligger i Github Package Registry som krever autentisering. Det enkleste er å lage
-en [PAT (Personal Access Token)](https://github.com/settings/tokens).
-
-1. [Opprett PAT her](https://github.com/settings/tokens). I tilfelle lenken ikke fungerer går man
-   til `Github -> Settings -> Developer settings -> Personal access tokens`
-2. Huk av `read:packages`. Ikke legg til flere scopes enn nødvendig.
-3. Autoriser navikt-organisasjonen for SSO ved å velge "Configure SSO" på tokenet
-4. Tokenet legges i `.zshrc` med `export GITHUB_TOKEN=<token>`
-
 # Felles apper
 
 Alle apper som er felles for Team Etterlatte ligger

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,11 +15,7 @@ subprojects.forEach { sub ->
     sub.repositories {
         mavenCentral()
         maven {
-            url = uri("https://maven.pkg.github.com/navikt/pensjon-etterlatte-libs")
-            credentials {
-                username = "token"
-                password = System.getenv("GITHUB_TOKEN")
-            }
+            url = uri("https://github-package-registry-mirror.gc.nav.no/cached/maven-release")
         }
     }
     sub.tasks {


### PR DESCRIPTION
Use github-package-registry-mirror.gc.nav.no droping the need for github username and password to get packages from github-package-registry