### PR TITLE
Legger på appid

### DIFF
--- a/apps/brukerdialog-sanity/sanity.cli.ts
+++ b/apps/brukerdialog-sanity/sanity.cli.ts
@@ -5,4 +5,7 @@ export default defineCliConfig({
         projectId: 'u0dlg8d8',
         dataset: 'production',
     },
+    deployment: {
+        appId: '414d0e3e2a5b29a91f70206b',
+    },
 })


### PR DESCRIPTION
Den siste deployen som gikk gjennom ba oss legge på appid i configen for å ikke bli promptet neste gang vi deployet. Det er sannsynligvis dette som gjør at sanity ikke kan deployes nå.

Denne kodesnutten kommer [herfra](https://github.com/navikt/pensjon-etterlatte/actions/runs/25721622274/job/75523954781):
````
Add appId: '414d0e3e2a5b29a91f70206b'
to the `deployment` section in sanity.cli.js or sanity.cli.ts
to avoid prompting for application id on next deploy.

Example:
export default defineCliConfig({
  //…
  deployment: {
    appId: '414d0e3e2a5b29a91f70206b',
  },
  //…
})
````